### PR TITLE
english: Use new unicode-ipa-syls to keep syllable boundaries

### DIFF
--- a/prosodic/dicts/en/english.py
+++ b/prosodic/dicts/en/english.py
@@ -242,7 +242,7 @@ def ipa2cmu(tok):
 
 def cmu2ipa(tok):
 	import lexconvert
-	res=lexconvert.convert(tok,'cmu','unicode-ipa')
+	res=lexconvert.convert(tok,'cmu','unicode-ipa-syls')
 
 	## BUG FIXES
 	if tok.endswith(' T') and not res.endswith('t'): res=res+'t'


### PR DESCRIPTION
Previously, parsing eSpeak-generated TTS phonemes using lexconvert would remove syllable boundaries. ssb22 has updated lexconvert to address this issue, see https://github.com/ssb22/lexconvert/issues/1

This PR updates Prosodic to use the new conversion provided by lexconvert.