### PR TITLE
Fix time.clock deprecation

### DIFF
--- a/prosodic/lib/Dictionary.py
+++ b/prosodic/lib/Dictionary.py
@@ -77,7 +77,7 @@ class Dictionary:	# cf Word, in that Text.py will really instantiate Dictionary_
 		build=False
 
 		## language objects
-		timestart=time.clock()
+		timestart=time.time()
 		if being.persists:
 			if __name__=='__main__':
 				print("## booting ontology: " + self.language + " ...")


### PR DESCRIPTION
time.clock is no longer supported in Python3, replacing it with
time.time.