### PR TITLE
Resolved setup.py install error, fix of #26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PostInstallCommand(install):
 	"""Post-installation for installation mode."""
 	def run(self):
 		tools.configure_home_dir(force=True)
-		install.run(self)
+		install.do_egg_install(self)
 
 if __name__ == '__main__':
 	with open("README.md", "r", encoding="utf8") as fh:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class PostInstallCommand(install):
 		install.run(self)
 
 if __name__ == '__main__':
-	with open("README.md", "r") as fh:
+	with open("README.md", "r", encoding="utf8") as fh:
 		long_description = fh.read()
 
 	with open("requirements.txt", "r") as fh:


### PR DESCRIPTION
Resolves #26

Hello!

This PR fixes two issues:
* This PR fixes the `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 11140: character maps to <undefined>` error when installing `prosodic`, whether it is via `pip install prosodic`, `pip install git+https://github.com/quadrismegistus/prosodic.git` and `python setup.py install`.
* This PR also fixes the issue that the requirements are not installed when the module is.

---

See https://github.com/quadrismegistus/prosodic/issues/26#issuecomment-784096299 for information on `How to replicate`, `The cause of the error` and `The fix`, for issue 1.

### After applying the fix for issue 1
```
(venv) PS C:\GitHub\prosodic> pip show prosodic
Name: prosodic
Version: 1.3.12
Summary: PROSODIC: a metrical-phonological parser, written in Python. For English and Finnish, with flexible language support.
Home-page: https://github.com/quadrismegistus/prosodic
Author: Ryan Heuser
Author-email: heuser@stanford.edu
License: MPL-2.0
Location: c:\github\prosodic\venv\lib\site-packages
Requires: nltk, numpy, Pyphen, pyparsing, xlrd, networkx, scipy, xlwt, levenshtein, p-tqdm
Required-by:
```

### Issue 2
As can be seen here: https://stackoverflow.com/questions/21915469/python-setuptools-install-requires-is-ignored-when-overriding-cmdclass, whenever `install` is subclassed like in https://github.com/quadrismegistus/prosodic/blob/83b9fc1010c3f4f44e9dc26f98f16b1fc6856ce5/setup.py#L31-L35, then the requirements are not installed. There is also a fix which works for us, replacing
```python
install.run(self)
```
with 
```python
install.do_egg_install(self)
```

The issue itself can be replicated by downloading `prosodic` via `python setup.py install` in a fresh virtualenvironment, and then typing `pip freeze`. You will find that only `prosodic` shows up, and none of the requirements. Naturally, `pip install -r requirements` will solve this, but so will the fix described above.

---

After these two fixes, I can run `python setup.py install` and then immediately `python -m prosodic.prosodic` without having to do any other manual installation. This puts me in the interactive terminal.
However, `prosodic` is still not a recognised command if I simply try `prosodic` in the terminal.

---

### What's next?

* I would heavily recommend increasing the version number in `setup.py` and uploading the new version to PyPI, as the install from there (with `pip install prosodic`) will still not work yet until you do so. 
* You may close #14 afterwards, as installing with `pip install prosodic` should work after this PR.
* You may close #26 as this is the fix for it.

---

Obviously you are free to replicate the issue using the instructions I gave, then clone https://github.com/CubieDev/prosodic, and apply the same install steps. You will see that it has resolved the issue.

- Tom Aarsen