### PR TITLE
Resolve pip install complications with ValueError: bad marshal data (unknown type code)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ include LICENSE.md
 include *.txt
 
 graft prosodic
-#graft prosodic
 graft metricaltree
 graft tagged_samples
 
@@ -13,4 +12,4 @@ graft meters
 graft dicts
 
 global-exclude .DS_Store
-global-exclude __pycache__
+global-exclude *.py[cod]


### PR DESCRIPTION
Hello!

Due to the great help of @tkarabela in https://github.com/quadrismegistus/prosodic/issues/27#issuecomment-808560457 comment, I was able to identify that the cause of the issue identified in https://github.com/quadrismegistus/prosodic/issues/27#issuecomment-792620324.

### The issue
The core of the issue is that 
```python
include_package_data=True,
```
in `setup.py` will copy all files mentioned by `MANIFEST.in` to be included in the installation. Because of a small mistake in this `MANIFEST.in` (and as can be seen in the outputs posted in #27), many `.pyc` (compiled Python) files were being included in the installation. This is really hard to spot for @quadrismegistus, as these `.pyc` files were generated by his version of Python, and will work for him upon installing. However, anyone else using a different version will get the following error upon installing:
```python
ValueError: bad marshal data (unknown type code)
```

### The fix
We don't want these `.pyc` files to be included. Rather, we want the local machine of the installee to generate them with their desired Python version. In fact, this was already attempted, by adding 
```
global-exclude __pycache__
```
to the `MANIFEST.in`. However, `global-exclude` takes a format for files, not a format for directories. (There is also `prune`, which does take directories, that is likely the source of the confusion)

This line has been replaced with 
```
global-exclude *.py[cod]
```
which will remove all generated Python files from being included in the installation. 

### How to check
First of all, after cloning my `pip_install` branch, you can use `python setup.py install` to generate three directories: `build`, `dist` and `prosodic.egg-info`. In the last one is a `SOURCES.txt` file, which contains all files that will be included in the installation. Previously, this file would include a whole bunch of `.pyc` files, but no longer.

### Installation output
After performing `python setup.py install`, my output is as follows:
```
(.env38) PS C:\GitHub\prosodic> python setup.py install
setup.py:20: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import sys,os,imp
running install
_here --> C:\GitHub\prosodic
here has files: ['.env38', '.git', '.gitignore', '.gitmodules', '.vscode', 'bin', 'build', 'corpora', 'dist', 'LICENSE.md', 'MANIFEST.in', 'meters', 'metricaltree', 'notebooks', 'prosodic', 'prosodic.egg-info', 'README.md', 'README_prosodic.txt', 'requirements.txt', 'setup.py', 'tagged_samples', 'tests']
copying C:\GitHub\prosodic\meters\default_english.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\iambic_pentameter.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\iambic_pentameter2.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\iambic_pentameter3.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\kiparskyhanson_hopkins.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\kiparskyhanson_shakespeare.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\litlab.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\meter_arto.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\meter_ryan.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\meter_ryan_categorical.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\prose_rhythm_iambic.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\prose_rhythm_iambic_inviolable.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\prose_rhythm_iambic_violable.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\strength_and_resolution.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\strength_only.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\meters\__init__.py -> C:\Users\Tom\prosodic_data\meters
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.alliteration.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.hopkins.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.shakespeare.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.test.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.whitman.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.yeats.early.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_en\en.yeats.late.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_en
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.erkko.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.hellaakoski.nimettomia.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.hellaakoski.runoja.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.kalevala.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.koskenniemi.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.onerva.liesilauluja.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.siljo.maan-puoleen.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
copying C:\GitHub\prosodic\corpora\corppoetry_fi\fi.siljo.teuvo-pakkala.txt -> C:\Users\Tom\prosodic_data\corpora\corppoetry_fi
running bdist_egg
running egg_info
writing prosodic.egg-info\PKG-INFO
writing dependency_links to prosodic.egg-info\dependency_links.txt
writing requirements to prosodic.egg-info\requires.txt
writing top-level names to prosodic.egg-info\top_level.txt
reading manifest file 'prosodic.egg-info\SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no directories found matching 'dicts'
warning: no previously-included files matching '.DS_Store' found anywhere in distribution
writing manifest file 'prosodic.egg-info\SOURCES.txt'
installing library code to build\bdist.win-amd64\egg
running install_lib
running build_py
creating build\lib\prosodic\dicts
creating build\lib\prosodic\dicts\en
copying prosodic\dicts\en\english.py -> build\lib\prosodic\dicts\en
copying prosodic\dicts\en\english.tsv -> build\lib\prosodic\dicts\en
copying prosodic\dicts\en\english.tts-cache.tsv -> build\lib\prosodic\dicts\en
copying prosodic\dicts\en\maybestressed.txt -> build\lib\prosodic\dicts\en
copying prosodic\dicts\en\syllabify.py -> build\lib\prosodic\dicts\en
copying prosodic\dicts\en\unstressed.txt -> build\lib\prosodic\dicts\en
creating build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\compound.txt -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\config.txt -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish.py~ -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_annotator.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_functions.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_sonority.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_stress.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_syllables.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_text.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\finnish_weight.py -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\initial.txt -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\presyllabified.txt -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\suffix.txt -> build\lib\prosodic\dicts\fi
copying prosodic\dicts\fi\unstressed.txt -> build\lib\prosodic\dicts\fi
creating build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\compound.txt -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\config.txt -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_annotator.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_functions.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_sonority.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_stress.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_syllables.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_text.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\finnish_weight.py -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\initial.txt -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\presyllabified.txt -> build\lib\prosodic\dicts\fi\syllabifier
copying prosodic\dicts\fi\syllabifier\suffix.txt -> build\lib\prosodic\dicts\fi\syllabifier
creating build\lib\prosodic\lib
copying prosodic\lib\Coda.py -> build\lib\prosodic\lib
copying prosodic\lib\Corpus.py -> build\lib\prosodic\lib
copying prosodic\lib\Dictionary.py -> build\lib\prosodic\lib
copying prosodic\lib\Line.py -> build\lib\prosodic\lib
copying prosodic\lib\MaxEnt.py -> build\lib\prosodic\lib
copying prosodic\lib\MaxEnt2.py -> build\lib\prosodic\lib
copying prosodic\lib\Meter.py -> build\lib\prosodic\lib
copying prosodic\lib\MeterConstraint.py -> build\lib\prosodic\lib
copying prosodic\lib\MeterPosition.py -> build\lib\prosodic\lib
copying prosodic\lib\MeterSlot.py -> build\lib\prosodic\lib
copying prosodic\lib\Nucleus.py -> build\lib\prosodic\lib
copying prosodic\lib\Onset.py -> build\lib\prosodic\lib
copying prosodic\lib\Parse.py -> build\lib\prosodic\lib
copying prosodic\lib\Phoneme.py -> build\lib\prosodic\lib
copying prosodic\lib\Rime.py -> build\lib\prosodic\lib
copying prosodic\lib\Sentence.py -> build\lib\prosodic\lib
copying prosodic\lib\Stanza.py -> build\lib\prosodic\lib
copying prosodic\lib\Syllable.py -> build\lib\prosodic\lib
copying prosodic\lib\SyllableBody.py -> build\lib\prosodic\lib
copying prosodic\lib\Text.py -> build\lib\prosodic\lib
copying prosodic\lib\Word.py -> build\lib\prosodic\lib
copying prosodic\lib\WordToken.py -> build\lib\prosodic\lib
copying prosodic\lib\entity.py -> build\lib\prosodic\lib
copying prosodic\lib\ipa.py -> build\lib\prosodic\lib
copying prosodic\lib\lexconvert.py -> build\lib\prosodic\lib
copying prosodic\lib\pickler.py -> build\lib\prosodic\lib
copying prosodic\lib\tools.py -> build\lib\prosodic\lib
creating build\lib\prosodic\lib\feats
copying prosodic\lib\feats\ipa.py -> build\lib\prosodic\lib\feats
copying metricaltree\README.md -> build\lib\metricaltree
copying metricaltree\get-deps.sh -> build\lib\metricaltree
creating build\bdist.win-amd64\egg
creating build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\deptree.py -> build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\get-deps.sh -> build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\metricaltree.py -> build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\README.md -> build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\test.py -> build\bdist.win-amd64\egg\metricaltree
copying build\lib\metricaltree\__init__.py -> build\bdist.win-amd64\egg\metricaltree
creating build\bdist.win-amd64\egg\prosodic
copying build\lib\prosodic\config.py -> build\bdist.win-amd64\egg\prosodic
creating build\bdist.win-amd64\egg\prosodic\dicts
creating build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\english.py -> build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\english.tsv -> build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\english.tts-cache.tsv -> build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\maybestressed.txt -> build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\syllabify.py -> build\bdist.win-amd64\egg\prosodic\dicts\en
copying build\lib\prosodic\dicts\en\unstressed.txt -> build\bdist.win-amd64\egg\prosodic\dicts\en
creating build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\compound.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\config.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish.py~ -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_annotator.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_functions.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_sonority.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_stress.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_syllables.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_text.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\finnish_weight.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\initial.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\presyllabified.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
copying build\lib\prosodic\dicts\fi\suffix.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
creating build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\compound.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\config.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_annotator.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_functions.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_sonority.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_stress.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_syllables.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_text.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\finnish_weight.py -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\initial.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\presyllabified.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\syllabifier\suffix.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier
copying build\lib\prosodic\dicts\fi\unstressed.txt -> build\bdist.win-amd64\egg\prosodic\dicts\fi
creating build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Coda.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Corpus.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Dictionary.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\entity.py -> build\bdist.win-amd64\egg\prosodic\lib
creating build\bdist.win-amd64\egg\prosodic\lib\feats
copying build\lib\prosodic\lib\feats\ipa.py -> build\bdist.win-amd64\egg\prosodic\lib\feats
copying build\lib\prosodic\lib\ipa.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\lexconvert.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Line.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\MaxEnt.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\MaxEnt2.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Meter.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\MeterConstraint.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\MeterPosition.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\MeterSlot.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Nucleus.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Onset.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Parse.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Phoneme.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\pickler.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Rime.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Sentence.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Stanza.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Syllable.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\SyllableBody.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Text.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\tools.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\Word.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\lib\WordToken.py -> build\bdist.win-amd64\egg\prosodic\lib
copying build\lib\prosodic\prosodic.py -> build\bdist.win-amd64\egg\prosodic
copying build\lib\prosodic\__init__.py -> build\bdist.win-amd64\egg\prosodic
byte-compiling build\bdist.win-amd64\egg\metricaltree\deptree.py to deptree.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\metricaltree\metricaltree.py to metricaltree.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\metricaltree\test.py to test.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\metricaltree\__init__.py to __init__.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\config.py to config.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\en\english.py to english.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\en\syllabify.py to syllabify.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish.py to finnish.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_annotator.py to finnish_annotator.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_functions.py to finnish_functions.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_sonority.py to finnish_sonority.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_stress.py to finnish_stress.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_syllables.py to finnish_syllables.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_text.py to finnish_text.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\finnish_weight.py to finnish_weight.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_annotator.py to finnish_annotator.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_functions.py to finnish_functions.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_sonority.py to finnish_sonority.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_stress.py to finnish_stress.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_syllables.py to finnish_syllables.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_text.py to finnish_text.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\dicts\fi\syllabifier\finnish_weight.py to finnish_weight.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Coda.py to Coda.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Corpus.py to Corpus.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Dictionary.py to Dictionary.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\entity.py to entity.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\feats\ipa.py to ipa.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\ipa.py to ipa.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\lexconvert.py to lexconvert.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Line.py to Line.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\MaxEnt.py to MaxEnt.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\MaxEnt2.py to MaxEnt2.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Meter.py to Meter.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\MeterConstraint.py to MeterConstraint.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\MeterPosition.py to MeterPosition.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\MeterSlot.py to MeterSlot.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Nucleus.py to Nucleus.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Onset.py to Onset.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Parse.py to Parse.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Phoneme.py to Phoneme.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\pickler.py to pickler.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Rime.py to Rime.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Sentence.py to Sentence.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Stanza.py to Stanza.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Syllable.py to Syllable.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\SyllableBody.py to SyllableBody.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Text.py to Text.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\tools.py to tools.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\Word.py to Word.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\lib\WordToken.py to WordToken.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\prosodic.py to prosodic.cpython-38.pyc
byte-compiling build\bdist.win-amd64\egg\prosodic\__init__.py to __init__.cpython-38.pyc
creating build\bdist.win-amd64\egg\EGG-INFO
installing scripts to build\bdist.win-amd64\egg\EGG-INFO\scripts
running install_scripts
running build_scripts
creating build\bdist.win-amd64\egg\EGG-INFO\scripts
copying build\scripts-3.8\prosodic -> build\bdist.win-amd64\egg\EGG-INFO\scripts
copying prosodic.egg-info\PKG-INFO -> build\bdist.win-amd64\egg\EGG-INFO
copying prosodic.egg-info\SOURCES.txt -> build\bdist.win-amd64\egg\EGG-INFO
copying prosodic.egg-info\dependency_links.txt -> build\bdist.win-amd64\egg\EGG-INFO
copying prosodic.egg-info\requires.txt -> build\bdist.win-amd64\egg\EGG-INFO
copying prosodic.egg-info\top_level.txt -> build\bdist.win-amd64\egg\EGG-INFO
zip_safe flag not set; analyzing archive contents...
prosodic.__pycache__.prosodic.cpython-38: module references __file__
prosodic.dicts.en.__pycache__.english.cpython-38: module references __file__
prosodic.lib.__pycache__.tools.cpython-38: module references __file__
creating 'dist\prosodic-1.4.0-py3.8.egg' and adding 'build\bdist.win-amd64\egg' to it
removing 'build\bdist.win-amd64\egg' (and everything under it)
Processing prosodic-1.4.0-py3.8.egg
creating c:\github\prosodic\.env38\lib\site-packages\prosodic-1.4.0-py3.8.egg
Extracting prosodic-1.4.0-py3.8.egg to c:\github\prosodic\.env38\lib\site-packages
Adding prosodic 1.4.0 to easy-install.pth file
Installing prosodic script to C:\GitHub\prosodic\.env38\Scripts

Installed c:\github\prosodic\.env38\lib\site-packages\prosodic-1.4.0-py3.8.egg
Processing dependencies for prosodic==1.4.0
Searching for p-tqdm==1.3.3
Best match: p-tqdm 1.3.3
Adding p-tqdm 1.3.3 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for levenshtein==0.12.0
Best match: levenshtein 0.12.0
Adding levenshtein 0.12.0 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for xlwt==1.3.0
Best match: xlwt 1.3.0
Adding xlwt 1.3.0 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for scipy==1.6.2
Best match: scipy 1.6.2
Adding scipy 1.6.2 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for networkx==2.5
Best match: networkx 2.5
Adding networkx 2.5 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for xlrd==2.0.1
Best match: xlrd 2.0.1
Adding xlrd 2.0.1 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for pyparsing==2.4.7
Best match: pyparsing 2.4.7
Adding pyparsing 2.4.7 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for Pyphen==0.10.0
Best match: Pyphen 0.10.0
Adding Pyphen 0.10.0 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for numpy==1.20.1
Best match: numpy 1.20.1
Adding numpy 1.20.1 to easy-install.pth file
Installing f2py-script.py script to C:\GitHub\prosodic\.env38\Scripts
Installing f2py.exe script to C:\GitHub\prosodic\.env38\Scripts

Using c:\github\prosodic\.env38\lib\site-packages
Searching for nltk==3.5
Best match: nltk 3.5
Adding nltk 3.5 to easy-install.pth file
Installing nltk-script.py script to C:\GitHub\prosodic\.env38\Scripts
Installing nltk.exe script to C:\GitHub\prosodic\.env38\Scripts

Using c:\github\prosodic\.env38\lib\site-packages
Searching for six==1.15.0
Best match: six 1.15.0
Adding six 1.15.0 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for pathos==0.2.7
Best match: pathos 0.2.7
Adding pathos 0.2.7 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for tqdm==4.59.0
Best match: tqdm 4.59.0
Adding tqdm 4.59.0 to easy-install.pth file
Installing tqdm-script.py script to C:\GitHub\prosodic\.env38\Scripts
Installing tqdm.exe script to C:\GitHub\prosodic\.env38\Scripts

Using c:\github\prosodic\.env38\lib\site-packages
Searching for setuptools==49.2.1
Best match: setuptools 49.2.1
Adding setuptools 49.2.1 to easy-install.pth file
Installing easy_install-script.py script to C:\GitHub\prosodic\.env38\Scripts
Installing easy_install.exe script to C:\GitHub\prosodic\.env38\Scripts
Installing easy_install-3.8-script.py script to C:\GitHub\prosodic\.env38\Scripts
Installing easy_install-3.8.exe script to C:\GitHub\prosodic\.env38\Scripts

Using c:\github\prosodic\.env38\lib\site-packages
Searching for decorator==4.4.2
Best match: decorator 4.4.2
Adding decorator 4.4.2 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for regex==2021.3.17
Best match: regex 2021.3.17
Adding regex 2021.3.17 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for joblib==1.0.1
Best match: joblib 1.0.1
Adding joblib 1.0.1 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for click==7.1.2
Adding click 7.1.2 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for multiprocess==0.70.11.1
Best match: multiprocess 0.70.11.1
Adding multiprocess 0.70.11.1 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for pox==0.2.9
Best match: pox 0.2.9
Adding pox 0.2.9 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for ppft==1.6.6.3
Best match: ppft 1.6.6.3
Adding ppft 1.6.6.3 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Searching for dill==0.3.3
Best match: dill 0.3.3
Adding dill 0.3.3 to easy-install.pth file

Using c:\github\prosodic\.env38\lib\site-packages
Finished processing dependencies for prosodic==1.4.0
```
Feel free to compare this to the output of @tkarabela's https://github.com/quadrismegistus/prosodic/issues/27#issuecomment-808560457, and you will see that no `.pyc` files are being copied, but only byte-compiled upon installation.

I suspect that this will resolve our `pip install` complications.

Oh, I also found a solution to `prosodic` not properly opening the interactive mode, but as that is a separate issue, I'll make a separate PR for it.

- Tom Aarsen