### PR TITLE
Resolves 'ERROR: prosodic==1.5.0 did not indicate that it installed an .egg-info directory' from #31

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PostInstallCommand(install):
 	"""Post-installation for installation mode."""
 	def run(self):
 		tools.configure_home_dir(force=True)
-		install.do_egg_install(self)
+		install.run(self)
 
 if __name__ == '__main__':
 	with open("README.md", "r", encoding="utf8") as fh:


### PR DESCRIPTION
Resolves #31

Hello!

This PR attempts to fix the following issue:
`ERROR: prosodic did not indicate that it installed an .egg-info directory. Only setup.py projects generating .egg-info directories are supported.` as output when installing prosodic with `pip` (`pip install prosodic`, `pip install git+git://github.com/quadrismegistus/prosodic.git` and even `pip install .` after cloning the repo) when using pip version 20.2.3 (and python 3.9.4).

Before applying the change, all three of these commands throw that exception. However, it should be noted that the install does seem to be correct, despite throwing an exception.

After the fix, which was taken from https://github.com/oracle/Skater/pull/304 and https://github.com/zerodha/pykiteconnect/pull/71, `pip install .` no longer seems to throw the exception. 
Note that this fix is a reversion of one of the changes in my #28. This change I made (to opt for do_egg_install) fixed an issue that caused only `prosodic` to be installed, and none of the requirements. It seems that reverting this change does not reintroduce that error, but this is something to watch out for.

---

### What now?
My advise is to clone this PR (or make the fix yourself quickly in your own branch), and play around with `pip install .` in a fresh virtualenv. Look out for errors, whether `prosodic` is installed or not, whether the required modules are installed or not, and whether the required files (e.g. corpora) are installed or not.

I haven't had the time to very thoroughly test this, so definitely try to mess around with it a bit.

---

Another word of advise is to set `pip install prosodic` as the recommended installation method in the readme, instead of `pip install git+git://github.com/quadrismegistus/prosodic.git`. (However, they both had this issue)

- Tom Aarsen