### PR TITLE
Deploy: clone master instead of app3

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -38,7 +38,7 @@ REPO=/opt/prosodic/repo
 if [ -d "$REPO/.git" ]; then
     cd "$REPO" && sudo -u prosodic git pull
 else
-    sudo -u prosodic git clone -b app3 https://github.com/quadrismegistus/prosodic.git "$REPO"
+    sudo -u prosodic git clone https://github.com/quadrismegistus/prosodic.git "$REPO"
 fi
 
 # --- Python venv ---


### PR DESCRIPTION
One-line change: deploy/setup.sh now clones master instead of app3 for fresh server provisioning. app3 was merged into master (PR #77), so no need to keep the separate deploy branch reference. Existing servers should be updated out-of-band.