### PR TITLE
Unify parse paths: entity/web path now evaluates all constraints

### DIFF
--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -362,25 +362,21 @@ def parse_batch(parse_units, meter, syll_df=None):
             else:
                 simple_lines.append(item)
 
-        # batch simple lines: evaluate constraints, then batch bounding on GPU
+        # batch simple lines: evaluate ALL constraints at once (self-describing
+        # vectorized dispatch), then batch bounding on GPU
         if simple_lines:
-            all_viols = []
-            constraint_index = None
-            for idx, wt, feats, sylls in simple_lines:
-                viols, ci = evaluate_constraints(
-                    feats, meter_vals, position_ids, position_sizes, constraint_names
-                )
-                all_viols.append(viols)
-                if constraint_index is None:
-                    constraint_index = ci
+            feats_list = [feats for (_, _, feats, _) in simple_lines]
+            all_viols_4d, constraint_index = evaluate_constraints_batch(
+                feats_list, meter_vals, position_ids, position_sizes, constraint_names
+            )  # (L, S, N, C)
 
             # batch bounding
-            all_viol_sums = np.stack([v.sum(axis=1) for v in all_viols])  # (L, S, C)
+            all_viol_sums = all_viols_4d.sum(axis=2)  # (L, S, C)
             unbounded_masks = compute_bounding_batch(all_viol_sums)  # (L, S)
 
             for i, (idx, wt, feats, sylls) in enumerate(simple_lines):
                 pl = LazyParseList(
-                    wt, meter, scansions, all_viols[i], constraint_index,
+                    wt, meter, scansions, all_viols_4d[i], constraint_index,
                     unbounded_masks[i], sylls, parse_unit=meter.parse_unit,
                 )
                 results[idx] = (wt, pl)
@@ -399,9 +395,10 @@ def parse_batch(parse_units, meter, syll_df=None):
                     wmv, wpi, wps = encode_scansions(wscans, wnsylls)
                 else:
                     wscans, wmv, wpi, wps = scansions, meter_vals, position_ids, position_sizes
-                wviols, wci = evaluate_constraints(
-                    wfeats, wmv, wpi, wps, constraint_names
+                wviols_4d, wci = evaluate_constraints_batch(
+                    [wfeats], wmv, wpi, wps, constraint_names
                 )
+                wviols = wviols_4d[0]  # (S, N, C)
                 wunb = compute_bounding(wviols, wci)
                 wsylls = wfeats["sylls"]
                 wpl = LazyParseList(
@@ -579,57 +576,6 @@ def encode_scansions(scansions, nsylls):
     result = (meter_vals, position_ids, position_sizes)
     _scansion_cache[cache_key] = result
     return result
-
-
-def evaluate_constraints(features, meter_vals, position_ids, position_sizes, constraint_names):
-    """Batch-evaluate all constraints across all scansions for a single line.
-
-    Args:
-        features: dict with arrays of shape (N,)
-        meter_vals: (S, N) bool
-        position_ids: (S, N) int
-        position_sizes: (S, N) int
-        constraint_names: list of constraint name strings
-
-    Returns:
-        viols: (S, N, C) int8 — violation matrix
-        constraint_index: dict mapping constraint name to index in C dimension
-    """
-    S, N = meter_vals.shape
-    C = len(constraint_names)
-    viols = np.zeros((S, N, C), dtype=np.int8)
-    constraint_index = {name: i for i, name in enumerate(constraint_names)}
-
-    stressed = features["stressed"][None, :]   # (1, N)
-    heavy = features["heavy"][None, :]
-    strong = features["strong"][None, :]
-    weak = features["weak"][None, :]
-    word_ids = features["word_ids"][None, :]
-    func_word = features["func_word"][None, :]
-
-    is_strong_pos = meter_vals
-    is_weak_pos = ~meter_vals
-
-    for cname in constraint_names:
-        ci = constraint_index[cname]
-        if cname == "w_stress":
-            viols[:, :, ci] = (stressed & is_weak_pos).astype(np.int8)
-        elif cname == "s_unstress":
-            viols[:, :, ci] = (~stressed & is_strong_pos).astype(np.int8)
-        elif cname == "w_peak":
-            viols[:, :, ci] = (strong.astype(bool) & is_weak_pos).astype(np.int8)
-        elif cname == "s_trough":
-            viols[:, :, ci] = (weak.astype(bool) & is_strong_pos).astype(np.int8)
-        elif cname == "foot_size":
-            viols[:, :, ci] = (position_sizes > 2).astype(np.int8)
-        elif cname == "unres_within":
-            _eval_unres_within(viols, ci, position_ids, position_sizes,
-                               word_ids, heavy, stressed, S, N)
-        elif cname == "unres_across":
-            _eval_unres_across(viols, ci, position_ids, position_sizes,
-                                word_ids, func_word, is_strong_pos, S, N)
-
-    return viols, constraint_index
 
 
 def evaluate_constraints_batch(features_list, meter_vals, position_ids, position_sizes, constraint_names):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -222,3 +222,32 @@ def test_vectorized_bounding():
 
     assert bp.foot_type == "iambic"
     assert bp.meter_str == "-+-+-+-+-+"
+
+
+def test_entity_path_evaluates_all_constraints():
+    """Regression: parse_batch (the entity/web parse path) must evaluate every
+    constraint via the vectorized dispatch, agreeing with parse_batch_from_df.
+
+    Before the two paths were unified, parse_batch used a single-line evaluator
+    that hardcoded only 7 constraints, so clash/lapse/s_func/w_heavy/s_light/
+    word_foot were silently all-zero on the entity path (which every web
+    endpoint uses)."""
+    from prosodic.parsing.meter import Meter
+    from prosodic.parsing.vectorized import parse_batch, parse_batch_from_df
+
+    m = Meter(constraints=["w_stress", "s_unstress", "clash", "s_func",
+                           "w_heavy", "word_foot"])
+    names = list(m.constraints.keys())
+    line = "And dig deep trenches in thy beautys field"
+
+    ent_mass = parse_batch(TextModel(line).lines, m)[0][1]._all_viols.sum(axis=(0, 1))
+    by = {n: int(ent_mass[i]) for i, n in enumerate(names)}
+    # these previously-ignored constraints all fire on this line
+    for n in ["clash", "s_func", "w_heavy", "word_foot"]:
+        assert by[n] > 0, f"{n} not evaluated on the entity path (mass={by[n]})"
+
+    # entity path must agree with the DF path on constraint totals
+    t = TextModel(line)
+    df_mass = list(parse_batch_from_df(t._syll_df, m).values())[0]._all_viols.sum(axis=(0, 1))
+    assert [int(x) for x in df_mass] == [int(x) for x in ent_mass], \
+        "DF and entity paths disagree on constraint totals"


### PR DESCRIPTION
Fixes the highest-impact correctness bug from the 2026-07 audit (P3/F1 in `AUDIT.md`): **the web app's parse path silently ignored 8 of 15 constraints.**

## The bug
Every web endpoint parses via `parse_batch` (the "entity" path). That function called a single-line `evaluate_constraints` helper that hardcoded only 7 constraints in an if/elif chain and never dispatched to the self-describing `cfunc.vectorized` lambdas. So `clash`, `lapse`, `s_func`, `w_heavy`, `s_light`, `word_foot`, `w_prom`, and `s_demoted` produced **all-zero** violation columns — enabling any of them in the Meter tab returned wrong parses. The DataFrame path (`text.parse()` → `parse_batch_from_df`) was already correct via `evaluate_constraints_batch`.

## The fix
Route `parse_batch` through `evaluate_constraints_batch` (the generic dispatcher the DF path uses):
- Simple (non-ambiguous) lines are now evaluated in **one batched call** instead of a per-line Python loop — a small perf win on top of the correctness fix.
- Ambiguous-form variants call it with L=1.
- The divergent `evaluate_constraints` is deleted (−65 net lines in `vectorized.py`).

## Verification
- Entity and DF paths now produce **byte-identical** `(S, N, C)` violation arrays on variant-stable lines.
- Per-constraint totals match where they were zero before: `clash 309/309`, `s_func 178/178`, `w_heavy 890/890`, `word_foot 380/380`.
- New test `test_entity_path_evaluates_all_constraints` locks this in.
- 73 tests pass (`test_parsing.py` + `test_v3.py`), plus the fast web + words/texts/client suites green.

## Scope note
The two paths still differ on **ambiguous-form selection** (DF explores "diagonal" form combos; entity uses the full wordtoken matrix) — a separate pre-existing issue tracked as C9/M3 in `AUDIT.md`, not addressed here.

Independent of #89 (branches off `master`); the two touch different regions of `vectorized.py` and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
