### PR TITLE
Fix client error details, cli shell call, and best_parses crash (W9/W10/C7)

### DIFF
--- a/prosodic/cli.py
+++ b/prosodic/cli.py
@@ -1,5 +1,6 @@
 from .imports import *
 import click
+import subprocess
 
 
 @click.group()
@@ -37,5 +38,4 @@ def ipython():
     """
     click.echo('Starting prosodic in ipython')
     imps = 'from prosodic import *\nimport prosodic'
-    cmd = f'ipython -i -c "{imps}"'
-    os.system(cmd)
+    subprocess.run(['ipython', '-i', '-c', imps])

--- a/prosodic/client.py
+++ b/prosodic/client.py
@@ -50,6 +50,26 @@ def get_server():
     return _server
 
 
+def _raise_with_detail(resp):
+    """Raise a RuntimeError including the server's JSON `detail` message, if any.
+
+    Falls back to the transport's own raise_for_status() (requests.HTTPError or
+    httpx.HTTPStatusError) when no JSON `detail` is present, so plain HTTP errors
+    still raise as before.
+    """
+    if resp.status_code >= 400:
+        detail = None
+        try:
+            body = resp.json()
+            if isinstance(body, dict):
+                detail = body.get('detail')
+        except Exception:
+            pass
+        if detail:
+            raise RuntimeError(f"{resp.status_code} error from server: {detail}")
+        resp.raise_for_status()
+
+
 class _HttpTransport:
     """Wraps either requests (URL string) or FastAPI TestClient."""
 
@@ -63,7 +83,7 @@ class _HttpTransport:
             resp = self._server.get(path, **kwargs)
         else:
             resp = requests.get(f"{self._server}{path}", timeout=timeout, **kwargs)
-        resp.raise_for_status()
+        _raise_with_detail(resp)
         return resp.json()
 
     def post(self, path, json=None, **kwargs):
@@ -72,7 +92,7 @@ class _HttpTransport:
             resp = self._server.post(path, json=json, **kwargs)
         else:
             resp = requests.post(f"{self._server}{path}", json=json, timeout=timeout, **kwargs)
-        resp.raise_for_status()
+        _raise_with_detail(resp)
         return resp.json()
 
 

--- a/prosodic/parsing/parselists.py
+++ b/prosodic/parsing/parselists.py
@@ -673,7 +673,8 @@ class ParseListList(EntityList):
     
     @cached_property
     def best_parses(self):
-        return ParseList([pl.best_parse for pl in self], parent=self.parent)
+        parses = (pl.best_parse for pl in self)
+        return ParseList([p for p in parses if p is not None], parent=self.parent)
     
     @property
     def best(self):


### PR DESCRIPTION
## Summary
Three small, independent robustness fixes from the repo audit (AUDIT.md: W9, W10, C7).

- **W9** — `prosodic/client.py`: `_HttpTransport.get()`/`.post()` called `resp.raise_for_status()` directly, discarding the FastAPI JSON `{"detail": ...}` body on error responses, so remote client users only saw an opaque `500 Server Error`. Added `_raise_with_detail(resp)`: if the response is an error and its JSON body has a `detail` field, raises `RuntimeError(f"{status_code} error from server: {detail}")`; otherwise falls back to the original `raise_for_status()` behavior (works for both `requests.Response` and `httpx.Response` from the FastAPI `TestClient`).
- **W10** — `prosodic/cli.py`: `ipython` command used `os.system(f'ipython -i -c "{imps}"')` (shell invocation). Replaced with `subprocess.run(['ipython', '-i', '-c', imps])` — no shell, `imps` passed as a single argv element. Added `import subprocess`. Behavior unchanged (still launches `ipython -i -c <imps>`).
- **C7** — `prosodic/parsing/parselists.py:674-676`: `ParseListList.best_parses` built `ParseList([pl.best_parse for pl in self], ...)`. For any per-line `ParseList`/`LazyParseList` with no unbounded parses (e.g. an oversized/prose line or an all-punctuation line that falls back to unparseable linepart handling), `pl.best_parse` is `None`, and `ParseList.append()` raises `ValueError: parse must be a Parse object` on construction — crashing `text.parse().best_parses` for any text containing one bad line. Fixed by filtering out `None` entries before constructing the `ParseList`.

## Test plan
- [x] `.venv/bin/python -c "import prosodic; from prosodic import client, cli"` succeeds
- [x] `pytest tests/test_client.py tests/test_parsing.py -q` — 40 passed
- [x] Reverted the C7 fix locally and confirmed `text.parse().best_parses` raises `ValueError: parse must be a Parse object` pre-fix, and returns cleanly (filtering the bad line) post-fix, using a text mixing a normal pentameter line with an oversized (24-syllable) line and an all-punctuation line
- [x] Verified `_raise_with_detail` surfaces `detail` via a synthetic FastAPI route raising `HTTPException(500, detail=...)` through a `TestClient`-backed transport, and falls back to `raise_for_status()` when no JSON body is present

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n