### PR TITLE
Fix MaxEnt gradient, line alignment, and prose-line crash

### DIFF
--- a/prosodic/parsing/maxent.py
+++ b/prosodic/parsing/maxent.py
@@ -140,9 +140,12 @@ class MaxEntTrainer:
             text = TextModel(text_input, lang=lang)
         results = parse_batch_from_df(text._syll_df, self.meter)
         line_nums = sorted(results.keys())
-        # map line_num -> original text by position
-        line_texts = [input_lines[i] if i < len(input_lines) else ""
-                      for i in range(len(line_nums))]
+        # Map each parsed line back to its source text by line_num. line_num is
+        # 1-based over non-empty lines (matching input_lines, which also drops
+        # blanks); the parser omits <2-syllable lines, so we must index by ln,
+        # not by enumerate position, or annotations attach to the wrong lines.
+        line_texts = [input_lines[ln - 1] if 0 <= ln - 1 < len(input_lines) else ""
+                      for ln in line_nums]
         return results, line_texts
 
     def _zone_split(self, viols_3d):
@@ -172,10 +175,16 @@ class MaxEntTrainer:
             lpl = results[ln]
             line_text = line_texts[i]
 
+            # Oversized/empty lines come back as a bare ParseList([]) with no
+            # violation matrix — skip them instead of crashing on _all_viols.
+            viols = getattr(lpl, "_all_viols", None)
+            if viols is None or viols.shape[0] == 0:
+                continue
+
             if self._base_constraint_names is None:
                 self._base_constraint_names = list(lpl._constraint_names)
 
-            nsylls = lpl._all_viols.shape[1]
+            nsylls = viols.shape[1]
             if nsylls > max_nsylls:
                 max_nsylls = nsylls
 
@@ -331,10 +340,14 @@ class MaxEntTrainer:
             safe_probs = np.clip(probs, 1e-30, None)
             neg_ll -= (observed * np.log(safe_probs)).sum()
 
-            # gradient: sum over lines of (observed - predicted) @ viols
-            diff = observed - probs  # (L, S)
-            # (L, S).T @ ... but we want sum over L of diff[l] @ viols[l]
-            # = einsum('ls,lsc->c', diff, viols)
+            # gradient: sum over lines of (observed - obs_sum * predicted) @ viols.
+            # obs_sum is 1 for a line with a matched annotation and 0 for a line
+            # whose annotation matched no candidate scansion; the latter must
+            # contribute 0 gradient, matching its 0 contribution to the LL.
+            # (Using plain `observed - probs` gives unmatched lines a spurious
+            # -probs gradient that pushes every weight toward -inf.)
+            obs_sum = observed.sum(axis=-1, keepdims=True)  # (L, 1)
+            diff = observed - obs_sum * probs  # (L, S)
             neg_grad -= np.einsum('ls,lsc->c', diff, viols)
 
         # L2 regularization

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -327,6 +327,45 @@ class TestSaveLoad:
         assert 'zone_weights' in meta['meter']
         assert len(meta['meter']['zone_weights']) > 0
 
+    def test_maxent_gradient_correct_with_unmatched_line(self):
+        # The MaxEnt gradient must match finite differences even when a line's
+        # annotation matches no candidate scansion (obs_sum == 0). Regression
+        # for `diff = observed - obs_sum * probs` (unmatched lines must
+        # contribute 0 gradient, matching their 0 log-likelihood).
+        from prosodic.parsing.meter import Meter
+        from prosodic.parsing.maxent import MaxEntTrainer
+        tr = MaxEntTrainer(Meter(), regularization=100.0)
+        tr.load_annotations([
+            ("Shall I compare thee to a summers day", "wswswswsws", 1.0),
+            # deliberately wrong-length scansion -> matches nothing -> obs_sum 0
+            ("Rough winds do shake the darling buds of May", "wswswsws", 1.0),
+        ])
+        tr._precompute()
+        assert any(ld["observed"].sum() == 0 for ld in tr._line_data), \
+            "test must exercise an unmatched line"
+        w = np.full(len(tr._constraint_names), -0.3)
+        _, grad = tr._neg_log_likelihood_and_grad(w)
+        eps = 1e-6
+        fd = np.zeros_like(w)
+        for i in range(len(w)):
+            wp = w.copy(); wp[i] += eps
+            wm = w.copy(); wm[i] -= eps
+            fp, _ = tr._neg_log_likelihood_and_grad(wp)
+            fm, _ = tr._neg_log_likelihood_and_grad(wm)
+            fd[i] = (fp - fm) / (2 * eps)
+        assert np.max(np.abs(grad - fd)) < 1e-4
+
+    def test_maxent_fit_prose_no_crash(self):
+        # meter.fit() must not crash when the text contains an oversized (prose)
+        # line the parser can't scan (comes back as a bare ParseList). Regression C4.
+        from prosodic.parsing.meter import Meter
+        prose = ("Shall I compare thee to a summers day\n"
+                 "this is a very long prose sentence that exceeds the maximum "
+                 "syllable parse unit limit and falls outside the normal line path")
+        m = Meter()
+        m.fit(prose, "wswswswsws")  # must not raise
+        assert m.zone_weights is not None
+
     def test_load_returns_textmodel(self):
         t = TextModel("From fairest creatures we desire increase")
         path = t.save(os.path.join(self.tmpdir, "test3"))


### PR DESCRIPTION
Fixes three correctness bugs in the MaxEnt weight learner (`parsing/maxent.py`) — **C2/C3/C4 in `AUDIT.md`**. These corrupt realistic `meter.fit()` runs, so they matter for anyone learning constraint weights.

## Bugs fixed

**C2 — gradient wrong for unmatched lines.** `_neg_log_likelihood_and_grad` used `diff = observed - probs`, which is only correct when `observed` sums to 1. A line whose annotation matched **no candidate scansion** (`obs_sum == 0` — common when a line's syllable count doesn't match the target) contributes 0 to the log-likelihood but got `diff = -probs`, a spurious gradient pushing every weight toward −∞ (checked only by regularization/bounds). Fix: `diff = observed - obs_sum · probs`.
- **Verified:** analytic gradient now matches finite differences to **1.7e-10** with an unmatched line present; before the fix it diverged.

**C3 — line/text misalignment.** `_parse_text` mapped parser results to source lines by `enumerate` position (`input_lines[i]`), but `parse_batch_from_df` drops lines with <2 syllables. So after any short line, every subsequent line got the **wrong text**, and annotations attached to the wrong lines. `line_num` is 1-based over non-empty lines, so map by `input_lines[ln-1]`.

**C4 — crash on prose lines.** `_build_line_data` read `lpl._all_viols` unconditionally, but oversized (prose) lines come back as a bare `ParseList([])` with no violation matrix — so `meter.fit()` raised `AttributeError` on any text containing one long line. Skip results without a violation matrix.

## Tests
Adds `test_maxent_gradient_correct_with_unmatched_line` (analytic vs finite-difference gradient with an unmatched line) and `test_maxent_fit_prose_no_crash`. Full `test_v3` + `test_parsing` = 74 pass.

Branches off `master`; touches only `maxent.py` + `test_v3.py` (no overlap with the other open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
