### PR TITLE
perf: batch spaCy over sentences in phrasal_stress (one nlp.pipe call)

### DIFF
--- a/prosodic/texts/phrasal_stress.py
+++ b/prosodic/texts/phrasal_stress.py
@@ -112,13 +112,19 @@ def add_phrasal_stress(syll_df, model="en_core_web_sm"):
         syll_df['phrasal_stress'] = pd.array([], dtype=pd.Int32Dtype())
         return syll_df
 
+    from spacy.tokens import Doc
     nlp = _get_nlp(model)
 
     # get unique words per sentence (form_idx 0 or -1, no duplicates)
     word_df = syll_df[syll_df['form_idx'].isin([0, -1])].drop_duplicates('word_num')
 
-    # group by sentence
     stress_by_word = {}
+
+    # First pass: build one pre-tokenized Doc per sentence, collecting the
+    # word_num bookkeeping in parallel. All-punctuation sentences produce no
+    # Doc; their words get None directly.
+    docs = []
+    doc_meta = []  # parallel to docs: (parse_word_nums, punc_word_nums)
     for sent_num, group in word_df.groupby('sent_num'):
         words = group['word_txt'].values
         word_nums = group['word_num'].values
@@ -134,15 +140,16 @@ def add_phrasal_stress(syll_df, model="en_core_web_sm"):
                 stress_by_word[wn] = None
             continue
 
-        # run spaCy on pre-tokenized words
-        from spacy.tokens import Doc
+        # pre-tokenized Doc; the spaCy pipeline runs on it below via nlp.pipe
         spaces = [True] * len(parse_words)
-        if len(spaces):
-            spaces[-1] = False
-        doc = Doc(nlp.vocab, words=list(parse_words), spaces=spaces)
-        for name, proc in nlp.pipeline:
-            doc = proc(doc)
+        spaces[-1] = False
+        docs.append(Doc(nlp.vocab, words=list(parse_words), spaces=spaces))
+        doc_meta.append((parse_word_nums, word_nums[is_punc]))
 
+    # Second pass: a single batched pipeline call over all sentence Docs
+    # instead of one nlp() call per sentence. nlp.pipe preserves input order,
+    # so zipping with doc_meta keeps each Doc aligned with its word_nums.
+    for doc, (parse_word_nums, punc_word_nums) in zip(nlp.pipe(docs), doc_meta):
         n = len(doc)
         # extract head indices (-1 for root)
         heads = np.array([
@@ -158,7 +165,7 @@ def add_phrasal_stress(syll_df, model="en_core_web_sm"):
             stress_by_word[wn] = int(stress[i])
 
         # punctuation gets None
-        for wn in word_nums[is_punc]:
+        for wn in punc_word_nums:
             stress_by_word[wn] = None
 
     # broadcast to syllable rows


### PR DESCRIPTION
## What

`add_phrasal_stress` (in `prosodic/texts/phrasal_stress.py`) ran one spaCy pipeline call per sentence inside a Python loop — N calls for N sentences. This rewrites it to build all pre-tokenized sentence `Doc` objects first, then run a single `nlp.pipe(docs)` pass so spaCy batches the work in one call.

## Why

Per-sentence pipeline calls prevent spaCy from batching the parser/tagger, which is where the cost is. `nlp.pipe` over the pre-built Docs batches internally. This addresses audit finding **T18** (performance).

## Behavior is identical

This is purely a batching optimization — the `phrasal_stress` column values do not change.

- Verified at the doc level: per-doc vs `nlp.pipe(docs)` produce identical `(head, pos, tag)` for every token.
- Verified end-to-end: the `phrasal_stress` column is **byte-identical** to the per-sentence version on **7194 syllable rows** (600 Shakespeare sonnet lines), comparing the git-HEAD implementation against this one in the same process (NA-safe elementwise compare).

## Speedup

| scope | before | after | speedup |
|---|---|---|---|
| `add_phrasal_stress` (isolated, best of 5, 600 lines) | 501 ms | 381 ms | 1.31x |
| syntax-enabled `TextModel` init (600 lines) | 0.77 s | 0.45 s | 1.71x |

## Tests

`pytest tests/ -k "not browser and not multiproc"` → **241 passed, 1 skipped**.

## Scope

Only `prosodic/texts/phrasal_stress.py` changed (+17 / -10). Notable edge cases preserved: all-punctuation sentences still map every word to `None` (no Doc built for them), and punctuation words within content sentences still get `<NA>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n