### PR TITLE
Cleanup: dead constants (D3) + fragile paths (R13)

### DIFF
--- a/prosodic/imports.py
+++ b/prosodic/imports.py
@@ -59,7 +59,6 @@ import panphon
 import panphon.sonority
 
 
-USE_CACHE = False
 HASHSTR_LEN = None
 DEFAULT_NUM_PROC = None
 SYLL_SEP = "."
@@ -67,23 +66,12 @@ SYLL_SEP = "."
 DEFAULT_USE_REGISTRY = False
 DEFAULT_COMBINE_BY = "line"
 
-PATH_MTREE = os.path.join(PATH_REPO, "metricaltree")
-sys.path.append(PATH_MTREE)
-DASHES = ["--", "–", "—"]
-REPLACE_DASHES = True
-PSTRESS_THRESH_DEFAULT = 2
-TOKENIZER = r"[^\s+]+"
 SEPS_PHRASE = set(',:;–—()[].!?"“”’‘')
 SEP_STANZA = "\n\n"
 SEP_PARA = "\n\n"
 SEP_LINE = "\n"
-DEFAULT_PARSE_MAXSEC = 30
-DEFAULT_LINE_LIM = None
-DEFAULT_PROCESSORS = {"tokenize": "combined"}
 MAX_SYLL_IN_PARSE_UNIT = 18
 MIN_SYLL_IN_PARSE_UNIT = None
-MIN_WORDS_IN_PHRASE = 2
-MAX_WORDS_IN_PHRASE = 15
 DEFAULT_LANG = "en"
 DEFAULT_SYNTAX = False
 DEFAULT_SYNTAX_MODEL = "en_core_web_sm"
@@ -256,13 +244,6 @@ Leese but their show; their substance still lives sweet."""
 
 sonnet2 = """Those hours, that with gentle work did frame
 The lovely gaze where every eye doth dwell,"""
-
-
-GROUPBY_STANZA = ["stanza_num"]
-GROUPBY_LINE = GROUPBY_STANZA + ["line_num", "sent_num", "sentpart_num"]
-GROUPBY_WORD = GROUPBY_LINE + ["wordtoken_num", "wordform_num"]
-GROUPBY_SYLL = GROUPBY_WORD + ["syll_num"]
-
 
 
 DEFAULT_CONSTRAINTS = [

--- a/prosodic/langs/finnish/finnish.py
+++ b/prosodic/langs/finnish/finnish.py
@@ -73,7 +73,11 @@ ipa2x=dict([("".join(v), k) for (k, v) in orth2phon.items()])
 
 
 class FinnishLanguage(LanguageModel):
-    pronunciation_dictionary_filename = os.path.join(PATH_DICTS,'en','english.tsv')
+    # Finnish is syllabified by rule (get_sylls_ll_rule), not from a
+    # pronunciation-dictionary file. The old value pointed at the English dict
+    # under a nonexistent data/dicts/ path; the attribute is never read anyway
+    # (only *_sep is), so keep it empty to match the LanguageModel default.
+    pronunciation_dictionary_filename = ""
     lang = 'fi'
     cache_fn = 'finnish_wordtypes'
 

--- a/prosodic/web/api.py
+++ b/prosodic/web/api.py
@@ -51,7 +51,30 @@ MAX_INPUT_CHARS = 500_000  # hard cap on submitted text length (DoS guard)
 _TEXT_CACHE_MAX = 32       # bound the TextModel cache to avoid unbounded growth
 
 STATIC_BUILD_DIR = os.path.join(os.path.dirname(__file__), "static_build")
-CORPORA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "corpora")
+
+
+def _resolve_corpora_dir():
+    """Locate the corpora/ directory across dev and installed layouts.
+
+    Prefers the repo-root corpora/ (present for `pip install -e .` and the
+    deployed server), then a copy shipped inside the prosodic/ package. If none
+    exist, returns the repo-root candidate so the path-containment check has a
+    stable base and list_corpora simply returns an empty list (glob finds no
+    files) rather than erroring for pip users without the corpora dir.
+    """
+    pkg_dir = os.path.dirname(os.path.dirname(__file__))  # prosodic/
+    candidates = [
+        os.path.join(pkg_dir, "..", "corpora"),  # repo root (editable install / repo)
+        os.path.join(pkg_dir, "corpora"),        # packaged inside the prosodic/ package
+    ]
+    for cand in candidates:
+        cand = os.path.normpath(cand)
+        if os.path.isdir(cand):
+            return cand
+    return os.path.normpath(candidates[0])
+
+
+CORPORA_DIR = _resolve_corpora_dir()
 
 _text_cache = OrderedDict()
 _text_cache_guard = threading.Lock()


### PR DESCRIPTION
Addresses AUDIT.md findings **D3** (dead constants) and **R13** (broken/fragile paths). Strictly scoped to `imports.py`, `langs/finnish/finnish.py`, and `web/api.py`.

## D3 — dead constants removed from `imports.py`
Each was grep-verified across `prosodic/` and `tests/` (and the whole repo) as **definition-only** with no external references before removal:

- `USE_CACHE`
- `PATH_MTREE` + its `sys.path.append(PATH_MTREE)` — the `metricaltree/` dir was already deleted in a prior merged PR, so this appended a nonexistent path at import time
- `DASHES`, `REPLACE_DASHES`
- `PSTRESS_THRESH_DEFAULT`
- `TOKENIZER`
- `DEFAULT_PARSE_MAXSEC`, `DEFAULT_LINE_LIM`, `DEFAULT_PROCESSORS`
- `MIN_WORDS_IN_PHRASE`, `MAX_WORDS_IN_PHRASE`
- `GROUPBY_STANZA`, `GROUPBY_LINE`, `GROUPBY_WORD`, `GROUPBY_SYLL` — a self-referential cluster; none referenced outside their own definitions

No constants were kept — all listed candidates were confirmed dead.

## R13 — fragile paths
- **`finnish.py`**: `pronunciation_dictionary_filename` pointed at `PATH_DICTS/en/english.tsv` — a nonexistent path (`data/dicts/` does not exist) and, oddly, the *English* dict inside the Finnish class. The attribute is never actually read anywhere (only `pronunciation_dictionary_filename_sep` is), and Finnish is syllabified by rule (`get_sylls_ll_rule`), not from a dict file. Set to `""` to match the `LanguageModel` base-class default. The real English dict lives at `prosodic/langs/english/english.tsv` and loads via `path_token2ipa`, unaffected.
- **`web/api.py`**: `CORPORA_DIR` resolved to `site-packages/../corpora` when pip-installed (non-editable), leaving the corpus dropdown empty. Now resolved via `_resolve_corpora_dir()` which prefers the repo-root `corpora/` (dev / editable install / deployed server), then a packaged `prosodic/corpora`, and falls back to a stable base path so `list_corpora` returns empty (never errors) if the dir is missing. The path-traversal containment check in `read_corpus` is unchanged.

## Verification
- `import prosodic; from prosodic.web import api` succeeds
- All removed constants confirmed absent from the module namespace; kept constants intact
- `CORPORA_DIR` resolves to an existing dir
- Finnish class loads with `pronunciation_dictionary_filename == ""`
- Test suite: **266 passed, 1 skipped** (browser), 2 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
