### PR TITLE
Fix texts.py correctness bugs (T3, T5, T7, T10, T16, T17)

### DIFF
--- a/prosodic/texts/texts.py
+++ b/prosodic/texts/texts.py
@@ -56,6 +56,11 @@ class TextModel(Entity):
                 "must provide either txt string or filename or token dataframe"
             )
         txt = clean_text(get_txt(txt, fn)).strip()
+        if not txt and not children and tokens_df is None:
+            raise ValueError(
+                "text is empty after cleaning whitespace; "
+                "provide non-whitespace text (or children/tokens_df)"
+            )
         lang = lang if lang else detect_lang(txt)
 
         # syntax options
@@ -157,20 +162,35 @@ class TextModel(Entity):
         lines = LineList.from_wordtokens(self.children, text=self)
 
         # attach any DF-based parse results to the line entities
-        if self._line_parse_results:
-            for meter_key, line_results in self._line_parse_results.items():
-                for line in lines:
-                    line_num = line.num
-                    if line_num in line_results:
-                        pl = line_results[line_num]
-                        # set parent to the line's WordTokenList
-                        wt_list = line.children
-                        if hasattr(wt_list, '_parses'):
-                            pl.parent = wt_list
-                            wt_list._parses = pl
-                        line._parses = pl
+        self._attach_line_parse_results(lines)
 
         return lines
+
+    def _attach_line_parse_results(self, lines=None):
+        """Attach DF-path parse results to (already-built) Line entities.
+
+        Called both from the ``lines`` cached_property (pre-access path) and
+        from ``parse_iter`` (so results still attach when ``.lines`` was built
+        before ``parse()`` ran).
+        """
+        if not self._line_parse_results:
+            return
+        if lines is None:
+            # only attach if lines have actually been built; don't force build
+            lines = self.__dict__.get('lines')
+        if lines is None:
+            return
+        for meter_key, line_results in self._line_parse_results.items():
+            for line in lines:
+                line_num = line.num
+                if line_num in line_results:
+                    pl = line_results[line_num]
+                    # set parent to the line's WordTokenList
+                    wt_list = line.children
+                    if hasattr(wt_list, '_parses'):
+                        pl.parent = wt_list
+                        wt_list._parses = pl
+                    line._parses = pl
 
     @cached_property
     def lineparts(self):
@@ -208,8 +228,10 @@ class TextModel(Entity):
     def to_hash(self) -> str:
         return hashstr(self._txt)
 
-    @property
+    @cached_property
     def hash(self):
+        # _txt and lang are immutable after init, so cache the serialized hash
+        # rather than re-serializing the full text on every access.
         pkg={"txt": self._txt, "lang": self.lang}
         return encode_hash(serialize(pkg))
 
@@ -275,6 +297,8 @@ class TextModel(Entity):
         parse_key = (meter.key, combine_by)
         if parse_key in self._parse_results:
             yield from self._parse_results[parse_key]
+            # T7: re-attach to already-built line entities (no-op if unbuilt)
+            self._attach_line_parse_results()
         else:
             self._parse_results[parse_key] = []
             last_unit = None
@@ -314,6 +338,11 @@ class TextModel(Entity):
                 last_unit._parses = new_parselist
                 self._parse_results[parse_key].append(new_parselist)
                 yield new_parselist
+
+            # T7: attach DF-path results to already-built line entities so
+            # `t.lines; t.parse()` populates line._parses (not just the
+            # pre-access `t.parse(); t.lines` path).
+            self._attach_line_parse_results()
 
     @property
     def parses(self) -> Any:
@@ -373,10 +402,22 @@ class TextModel(Entity):
         chunks = []
         constraint_names = None
 
-        # use only the most recent meter's results — mixing constraint sets
-        # across meters would break the shared violation columns
-        latest_key = next(reversed(self._line_parse_results))
-        line_results = self._line_parse_results[latest_key]
+        # Use the results for the meter implied by **meter_kwargs (the one
+        # parse() just used), NOT simply the most-recently-parsed meter.
+        # Mixing constraint sets across meters would break the shared
+        # violation columns, so resolve the exact key. Fall back to the latest
+        # key only when no meter_kwargs were given (default meter).
+        if meter_kwargs:
+            target_key = self.get_meter(**meter_kwargs).key
+            line_results = self._line_parse_results.get(target_key)
+            if line_results is None:
+                line_results = self._line_parse_results[
+                    next(reversed(self._line_parse_results))
+                ]
+        else:
+            line_results = self._line_parse_results[
+                next(reversed(self._line_parse_results))
+            ]
         for line_num in sorted(line_results.keys()):
             pl = line_results[line_num]
             sylls = getattr(pl, '_sylls', None)
@@ -633,6 +674,11 @@ class TextModel(Entity):
         obj._children_data = obj.children_type(parent=obj) if obj.children_type is not None else []
         obj._parse_results = {}
         obj._line_parse_results = {}
+        # mirror __init__ so `.lineparts` (and syntax-aware paths) work on a
+        # loaded model instead of raising / recursing (T5).
+        obj._linepart_parse_results = {}
+        obj._syntax = DEFAULT_SYNTAX
+        obj._syntax_model = DEFAULT_SYNTAX_MODEL
         obj._parses = None
         obj._attrs = {'lang': meta.get('lang', DEFAULT_LANG)}
         obj._num = None
@@ -759,15 +805,23 @@ def Text(
     children: Optional[list] = [],
     tokens_df: Optional[pd.DataFrame] = None,
     server: Optional[str] = None,
+    syntax: Optional[bool] = None,
+    syntax_model: Optional[str] = None,
+    **kwargs,
 ):
     # Check for remote server (explicit arg or global setting)
     from ..client import get_server, RemoteText
     remote = server or get_server()
     if remote:
-        return RemoteText(txt=txt, fn=fn, server=remote)
+        return RemoteText(
+            txt=txt, fn=fn, server=remote,
+            syntax=syntax, syntax_model=syntax_model, **kwargs,
+        )
 
     return TextModel(
-        txt=txt, fn=fn, lang=lang, parent=parent, children=children, tokens_df=tokens_df
+        txt=txt, fn=fn, lang=lang, parent=parent, children=children,
+        tokens_df=tokens_df, syntax=syntax, syntax_model=syntax_model,
+        **kwargs,
     )
 
 

--- a/tests/test_texts.py
+++ b/tests/test_texts.py
@@ -36,3 +36,77 @@ def test_Text():
     assert t.txt == "ererer e   e"
     assert len(t.wordtokens) == 3
     assert t.attrs
+
+
+LINE = "From fairest creatures we desire increase"
+
+
+def test_empty_text_raises():
+    # T10: whitespace-only / empty text should raise a clear ValueError,
+    # not build a (0, 0) frame that later crashes in .save().
+    for bad in ("   ", "\t\n ", "", "     "):
+        with pytest.raises(ValueError):
+            TextModel(bad)
+
+
+def test_text_factory_syntax_kwarg():
+    # T17: the documented Text() factory must accept syntax= without TypeError.
+    from prosodic.texts.texts import Text
+    t = Text(LINE, syntax=False)
+    assert isinstance(t, TextModel)
+    assert t._syntax is False
+    # syntax_model also passes through
+    t2 = Text(LINE, syntax=False, syntax_model="en_core_web_sm")
+    assert t2._syntax_model == "en_core_web_sm"
+
+
+def test_hash_cached():
+    # T16: .hash should be cached (cached_property), not recomputed every call.
+    from functools import cached_property
+    assert isinstance(TextModel.__dict__["hash"], cached_property)
+    t = TextModel(LINE)
+    h = t.hash
+    assert "hash" in t.__dict__ and t.__dict__["hash"] == h
+    assert t.hash == h
+
+
+def test_get_parses_df_correct_meter():
+    # T3: get_parses_df(**kwargs) must return the meter implied by kwargs,
+    # not simply the most-recently-parsed meter.
+    t = TextModel(LINE)
+    b1 = len(t.get_parses_df(mode="all", max_w=1))   # strict meter B
+    a1 = len(t.get_parses_df(mode="all", max_w=2))   # default-ish meter A
+    assert b1 != a1, "meters should produce different parse spaces"
+    # A is now the most-recently-inserted key; querying B by kwargs must
+    # still return B's results, not A's.
+    b2 = len(t.get_parses_df(mode="all", max_w=1))
+    assert b2 == b1
+
+
+def test_load_lineparts_roundtrip():
+    # T5: TextModel.load(path).lineparts must work (previously RecursionError
+    # because _linepart_parse_results / _syntax / _syntax_model were unset).
+    t = TextModel(LINE + "\nWhen forty winters shall besiege thy brow")
+    t.parse()
+    with tempfile.TemporaryDirectory() as d:
+        path = t.save(d)
+        loaded = TextModel.load(path)
+        assert loaded._linepart_parse_results == {}
+        assert loaded._syntax is DEFAULT_SYNTAX
+        assert isinstance(loaded._syntax_model, str)
+        lineparts = loaded.lineparts  # must not raise
+        assert len(lineparts) >= 1
+
+
+def test_parse_attaches_after_lines():
+    # T7: parse results must attach to Line entities even when .lines was
+    # accessed before parse() ran.
+    t = TextModel(LINE)
+    _ = t.lines            # build lines first
+    t.parse()              # then parse (DF path)
+    assert t.lines[0]._parses is not None
+    assert t.lines[0].best_parse is not None
+    # pre-access path (parse before lines) still works
+    t2 = TextModel(LINE)
+    t2.parse()
+    assert t2.lines[0]._parses is not None


### PR DESCRIPTION
Bundle of verified correctness fixes in `prosodic/texts/texts.py` (from the audit). Scope: only `prosodic/texts/texts.py` + tests in `tests/test_texts.py`.

## Fixes

- **T3** — `get_parses_df()`/`save()` returned the most-recently-parsed meter's results (`next(reversed(self._line_parse_results))`) instead of the meter implied by `**meter_kwargs`. Now resolve the target key via `get_meter(**kwargs).key` when kwargs are given; fall back to the latest key only for the no-kwargs (default) case. (`texts.py` ~L380)
- **T5** — `TextModel.load()` never set `_linepart_parse_results` / `_syntax` / `_syntax_model`, so `.lineparts` on a loaded model raised (surfaced as RecursionError). Initialize all three, mirroring `__init__`. (`texts.py` load())
- **T7** — DF-path parse results only attached to `Line` entities if `parse()` ran *before* `.lines` was first accessed. Factored the attach loop into `_attach_line_parse_results()` and also call it from `parse_iter`, so `t.lines; t.parse()` populates `line._parses` (no silent fallback to slow per-line re-parsing). Pre-access path unchanged. (`texts.py` lines/parse_iter)
- **T10** — whitespace-only/empty text passed the `not txt` guard (checked before `.strip()`), built a `(0,0)` frame, then crashed in `.save()`. Now raise a clear `ValueError` after cleaning (only when no `children`/`tokens_df` provide the content). (`texts.py` __init__)
- **T16** — `TextModel.hash` re-serialized the full text every call. Made it a `cached_property` (`_txt`/`lang` immutable after init). (`texts.py` hash)
- **T17** — `Text()` factory couldn't pass `syntax=`/`syntax_model=` (documented feature unreachable). Added `syntax`/`syntax_model`/`**kwargs` passthrough to both the local and remote (`RemoteText`) paths. (`texts.py` Text())

## Tests

Added 6 focused tests in `tests/test_texts.py`: empty/whitespace raises (T10), `Text(syntax=...)` (T17), cached hash (T16), correct-meter `get_parses_df` (T3), `load().lineparts` roundtrip (T5), parse-after-lines attachment (T7).

## Verification

- `import prosodic` succeeds
- `tests/test_texts.py` + `tests/test_v3.py`: **69 passed**
- `tests/test_client.py` (exercises the `Text()` factory): **28 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n