### PR TITLE
CI/release: tag-gated PyPI publishing, PR tests, test infra cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: "release"
+
+# Deliberate-release path: only fires on a version tag push
+# (`git tag v3.3.1 && git push origin v3.3.1`), unlike stable-release.yml
+# which runs on every master push (tests + deploy only, no PyPI upload).
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tests:
+    uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
+
+  pre-release:
+    name: "GitHub Release"
+    needs: [tests]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Releasing"
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "stable"
+          prerelease: false
+          title: "Stable Build"
+
+  pypi-release:
+    name: "PyPI Release"
+    needs: [tests, pre-release]
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m build
+          twine upload dist/*

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -18,40 +18,12 @@ jobs:
   tests:
     uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
 
-  pre-release:
-    name: "GitHub Release"
-    needs: [tests]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Releasing"
-        uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "stable"
-          prerelease: false
-          title: "Stable Build"
-
-  pypi-release:
-    name: "PyPI Release"
-    needs: [tests, pre-release]
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python -m build
-          twine upload --skip-existing dist/*
+  # NOTE: the GitHub release + PyPI upload used to live here, gated only on
+  # `needs: [tests]` — every push to master published a new PyPI build. That
+  # moved to release.yml, triggered on `v*` tags, so a PyPI release is now a
+  # deliberate act (`git tag vX.Y.Z && git push --tags`). This workflow keeps
+  # only what should run on every master push: tests + continuous deploy of
+  # the live site.
 
   deploy:
     name: "Deploy to prosodic.app"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,37 +1,35 @@
 name: unit tests
 
-on: [workflow_call]
-  # push: # run on every push or PR to any branch
-  # pull_request:   # redundant?
+on:
+  workflow_call:      # invoked by stable-release.yml / release.yml / nonreleases.yml
+  pull_request:        # run directly on PRs (incl. from forks/branches) so they're actually tested
 
 
 jobs:
   python-unit:
-    name: Python unit tests
+    name: Python unit tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # NOTE: Python version to use is stored in the .python-version file, which is the
-      # convention for pyenv: https://github.com/pyenv/pyenv
-      - name: Get Python version
-        run: echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
-
-      # use python version for current build
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
-            pip-${{ env.PYTHON_VERSION }}
+            pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+            pip-${{ matrix.python-version }}
             pip-
 
       - name: Install dependencies
@@ -41,6 +39,12 @@ jobs:
           pip install -r requirements.txt
           pip install -r dev-requirements.txt
 
+      # Lightweight lint: byte-compile the package to catch syntax errors.
+      # Non-blocking (yapf's full diff isn't wired up as a dependency yet).
+      - name: Lint (compile check)
+        run: python -m compileall -q prosodic
+        continue-on-error: true
+
       - name: Prepare Selenium
         uses: nanasess/setup-chromedriver@master
 
@@ -48,7 +52,7 @@ jobs:
         run: env NAPTIME=30 pytest --cov=prosodic --cov-report=xml
 
       - name: Upload test coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: python
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,8 @@ all = [
 
 [project.scripts]
 prosodic = "prosodic.cli:cli"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with -k \"not slow\")",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest setup for the tests/ suite.
+
+Every test_*.py file repeats the same two lines before it can `import
+prosodic`:
+
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+    from prosodic.imports import *
+
+conftest.py is collected by pytest before any test module, so putting the
+sys.path fix here means the repo root is importable regardless of which
+directory pytest is invoked from, without every test file needing to set it
+up itself. (The `from prosodic.imports import *` star-import still has to
+stay in each test file — conftest.py can't inject names into another
+module's namespace.)
+"""
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -120,7 +120,9 @@ def test_on_error_raise(tmp_out):
 # --- multiprocessing ---
 
 # Skipped in CI: spawned workers re-import prosodic (torch + espeak) which
-# can hang on GitHub-hosted runners. Works fine locally.
+# can hang on GitHub-hosted runners. Works fine locally, but slow (spawns
+# real subprocesses) -- marked so `-k "not slow"` can deselect it too.
+@pytest.mark.slow
 @pytest.mark.skipif(
     bool(os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')),
     reason='multiprocessing spawn can hang in CI',


### PR DESCRIPTION
## Summary

Fixes AUDIT.md findings R5, R9, R11 (CI + release pipeline). Scope limited to `.github/workflows/`, `pyproject.toml`, `tests/conftest.py` (new), and the slow-test marker in `tests/test_batch.py`.

**R5 - tag-gated PyPI releases**
- `stable-release.yml` (push to master): now only `tests` -> `deploy`. The GitHub release and PyPI upload jobs were removed from this trigger. The `concurrency:` guard on the deploy job is preserved unchanged; the deploy SSH script is untouched.
- New `release.yml` (push of tag `v*`): `tests` -> `pre-release` (GitHub release) -> `pypi-release` (`twine upload dist/*`, `--skip-existing` dropped since a tag push is a deliberate release). `PYPI_API_TOKEN` env kept as before.
- Net effect: PyPI is no longer published on every master push; it publishes only when someone pushes a version tag (`git tag v3.x.y && git push origin v3.x.y`). The live site still redeploys on every master push, as before.

**R9 - CI coverage gaps**
- `unit-tests.yml` (the callable test workflow) now triggers on `workflow_call` (used by `stable-release.yml`, `release.yml`, `nonreleases.yml`) plus a direct `pull_request` trigger, so branch and fork PRs actually run tests.
- Added a Python version matrix: 3.10 and 3.12.
- Bumped actions: `actions/checkout@v3` to `v4`, `actions/setup-python@v3` to `v5`, `actions/cache@v3` to `v4`, `codecov/codecov-action@v3` to `v4`.
- Added a non-blocking lint step (`python -m compileall -q prosodic`, `continue-on-error: true`) rather than wiring up yapf, since yapf is not currently a declared project dependency; compileall needs nothing extra installed.

**R11 - test infra**
- Added `tests/conftest.py` with the repo-root `sys.path.append` that every `test_*.py` file currently repeats, so pytest can resolve `import prosodic` regardless of invocation directory without every test file needing its own copy. (Each test file still keeps its own `from prosodic.imports import *` star-import - conftest.py cannot inject names into another module namespace.)
- Marked `tests/test_batch.py::test_multiprocessing` with `@pytest.mark.slow` (kept its existing CI skipif intact) and registered the `slow` marker under `[tool.pytest.ini_options]` in `pyproject.toml`.

## What triggers what (explicit)

| Workflow | Trigger | Jobs |
|---|---|---|
| `stable-release.yml` | push to `master`/`main` | `tests`, `deploy` |
| `release.yml` (new) | push of tag matching `v*` | `tests`, `pre-release` (GitHub release), `pypi-release` (twine upload) |
| `unit-tests.yml` | `workflow_call` (from the three workflows above/below) AND direct `pull_request` | `python-unit` (matrix: Python 3.10, 3.12) |
| `nonreleases.yml` | push to any branch except `master`/`main`/`develop` | calls `unit-tests.yml` |
| `latest-release.yml` | push to `develop` | calls `unit-tests.yml`, then `build-deploy` (unchanged, not in scope) |

## Test plan

- [x] `.venv/bin/python -c "import prosodic"` succeeds.
- [x] All `.github/workflows/*.yml` parse as valid YAML (`yaml.safe_load` on each file).
- [x] `pytest tests/test_batch.py -q -k "not slow"` deselects `test_multiprocessing` (`10 passed, 1 skipped, 1 deselected`); no unknown-marker warning, confirming the `pyproject.toml` marker registration is picked up.

## Flagging for review (not guessed at)

- `release.yml`'s GitHub-release job still creates/moves the rolling `automatic_release_tag: "stable"` GitHub Release (unchanged from the prior behavior) - it is now gated behind an actual `v*` tag push rather than every master push, but it does not create a release named after the pushed tag itself. If the intent is for the GitHub Release to be named/tagged after the pushed version tag, that needs a follow-up change to the `marvinpinto/action-automatic-releases` config (or a different action).
- Local reusable workflows invoked via `uses: ./.github/workflows/unit-tests.yml` (no `secrets: inherit`) may not actually receive `CODECOV_TOKEN`/`GITHUB_TOKEN` from the caller under current GitHub Actions semantics - this is pre-existing behavior, not something this PR changes or attempts to fix.
- Did not add `pip install yapf` to wire up the yapf diff step the task offered as an option, since yapf is not declared anywhere as a project dependency; picked the dependency-free `compileall` option per the "pick the lighter one" instruction. Flagging in case the intent was actually to add yapf as a new dev dependency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
