### PR TITLE
perf(bounding): memory-budgeted harmonic bounding (chunk L, tile SxS)

### DIFF
--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -820,46 +820,117 @@ def compute_bounding_batch(viol_sums):
     return result
 
 
-def _compute_bounding_batch_numpy(viol_sums):
-    """Numpy batched bounding for L lines."""
+# Peak-memory budget (bytes) for the largest pairwise-difference intermediate
+# built during harmonic bounding. The pre-tiling implementation materialized a
+# single (L, S, S, C) tensor — ~1 GB (GPU int16) / ~4 GB (numpy int64) per
+# non-perfect line at the syllable cap (S ~ 8000+). The chunked/tiled path below
+# keeps the (Lc, Ti, Tj, C) diff tensor under this budget (derived boolean
+# masks add a small constant multiple). Tiling is a pure reassociation of the
+# same per-pair AND/OR dominance reduction, so the unbounded/bounded RESULT is
+# byte-identical to the untiled computation.
+BOUNDING_MEM_BUDGET = 128 * 1024 * 1024  # 128 MB
+
+
+def _bounding_block_sizes(L, S, C, bytes_per_elem, budget=None):
+    """Pick (Lc, Ti, Tj) block sizes so the (Lc, Ti, Tj, C) diff intermediate
+    stays within ``budget`` bytes.
+
+    Purely a memory-vs-speed tradeoff — it changes how the S x S comparison is
+    decomposed into tiles, never the bounded/unbounded result. When the whole
+    (L, S, S) comparison already fits the budget, returns (L, S, S) so the
+    computation is done in a single allocation (identical to the untiled path).
+    """
+    import math
+    if budget is None:
+        budget = BOUNDING_MEM_BUDGET
+    C = max(1, int(C))
+    # number of (line, i, j) triples whose diff (times C, times bytes) fits
+    max_elems = max(1, int(budget) // (int(bytes_per_elem) * C))
+    if L * S * S <= max_elems:
+        return L, S, S
+    # tile the S x S plane into square-ish tiles, then batch as many lines as
+    # the remaining budget allows.
+    tile = max(1, min(S, math.isqrt(max_elems)))
+    per_line_pairs = tile * tile
+    Lc = max(1, min(L, max_elems // per_line_pairs))
+    return int(Lc), int(tile), int(tile)
+
+
+def _compute_bounding_batch_numpy(viol_sums, budget=None):
+    """Numpy batched bounding for L lines (chunked over L, tiled over S x S).
+
+    Result is byte-identical to the untiled version: bounded[l, j] is the OR
+    over all i of (i dominates j), computed here by ORing partial reductions
+    over i-tiles.
+    """
     L, S, C = viol_sums.shape
-    # (L, S, 1, C) - (L, 1, S, C) -> (L, S, S, C)
-    diff = viol_sums[:, :, None, :] - viol_sums[:, None, :, :]
-    i_leq_j = (diff <= 0).all(axis=3)  # (L, S, S)
-    i_lt_j = i_leq_j & (diff < 0).any(axis=3)
-    bounded = i_lt_j.any(axis=1)  # (L, S)
+    if S <= 1:
+        return np.ones((L, S), dtype=bool)
+    Lc, Ti, Tj = _bounding_block_sizes(L, S, C, bytes_per_elem=8, budget=budget)
+    bounded = np.zeros((L, S), dtype=bool)
+    for l0 in range(0, L, Lc):
+        l1 = min(l0 + Lc, L)
+        vL = viol_sums[l0:l1]  # (lc, S, C)
+        for j0 in range(0, S, Tj):
+            j1 = min(j0 + Tj, S)
+            vj = vL[:, j0:j1, :]  # (lc, tj, C)
+            acc = np.zeros((l1 - l0, j1 - j0), dtype=bool)  # bounded within j-tile
+            for i0 in range(0, S, Ti):
+                i1 = min(i0 + Ti, S)
+                vi = vL[:, i0:i1, :]  # (lc, ti, C)
+                diff = vi[:, :, None, :] - vj[:, None, :, :]  # (lc, ti, tj, C)
+                i_leq_j = (diff <= 0).all(axis=3)
+                i_lt_j = i_leq_j & (diff < 0).any(axis=3)
+                acc |= i_lt_j.any(axis=1)  # reduce over this i-tile
+            bounded[l0:l1, j0:j1] = acc
     return ~bounded
 
 
-def _compute_bounding_batch_torch(viol_sums, device):
-    """GPU batched bounding for L lines in a single kernel launch."""
+def _compute_bounding_batch_torch(viol_sums, device, budget=None):
+    """GPU batched bounding for L lines (chunked over L, tiled over S x S).
+
+    Only the (Lc, Ti, Tj, C) diff tensor is tiled; the (L, S, C) input tensor is
+    uploaded once. Result is byte-identical to the untiled kernel.
+    """
     import torch
+    L, S, C = viol_sums.shape
+    if S <= 1:
+        return np.ones((L, S), dtype=bool)
     vt = torch.tensor(viol_sums, dtype=torch.int16, device=device)  # (L, S, C)
-    diff = vt[:, :, None, :] - vt[:, None, :, :]  # (L, S, S, C)
-    i_leq_j = (diff <= 0).all(dim=3)
-    i_lt_j = i_leq_j & (diff < 0).any(dim=3)
-    bounded = i_lt_j.any(dim=1)  # (L, S)
+    Lc, Ti, Tj = _bounding_block_sizes(L, S, C, bytes_per_elem=2, budget=budget)
+    bounded = torch.zeros((L, S), dtype=torch.bool, device=device)
+    for l0 in range(0, L, Lc):
+        l1 = min(l0 + Lc, L)
+        vL = vt[l0:l1]  # (lc, S, C)
+        for j0 in range(0, S, Tj):
+            j1 = min(j0 + Tj, S)
+            vj = vL[:, j0:j1, :]  # (lc, tj, C)
+            acc = torch.zeros((l1 - l0, j1 - j0), dtype=torch.bool, device=device)
+            for i0 in range(0, S, Ti):
+                i1 = min(i0 + Ti, S)
+                vi = vL[:, i0:i1, :]  # (lc, ti, C)
+                diff = vi[:, :, None, :] - vj[:, None, :, :]  # (lc, ti, tj, C)
+                i_leq_j = (diff <= 0).all(dim=3)
+                i_lt_j = i_leq_j & (diff < 0).any(dim=3)
+                acc |= i_lt_j.any(dim=1)  # reduce over this i-tile
+            bounded[l0:l1, j0:j1] = acc
     return ~bounded.cpu().numpy()
 
 
-def _compute_bounding_numpy(v):
-    """Numpy fallback for harmonic bounding (single line)."""
-    diff = v[:, None, :] - v[None, :, :]  # (S, S, C)
-    i_leq_j = (diff <= 0).all(axis=2)
-    i_lt_j = i_leq_j & (diff < 0).any(axis=2)
-    bounded = i_lt_j.any(axis=0)
-    return ~bounded
+def _compute_bounding_numpy(v, budget=None):
+    """Numpy fallback for harmonic bounding (single line). Tiled for large S."""
+    S = v.shape[0]
+    if S <= 1:
+        return np.ones(S, dtype=bool)
+    return _compute_bounding_batch_numpy(v[None, :, :], budget=budget)[0]
 
 
-def _compute_bounding_torch(v, device):
-    """GPU-accelerated harmonic bounding via PyTorch (single line)."""
-    import torch
-    vt = torch.tensor(v, dtype=torch.int16, device=device)
-    diff = vt[:, None, :] - vt[None, :, :]  # (S, S, C)
-    i_leq_j = (diff <= 0).all(dim=2)
-    i_lt_j = i_leq_j & (diff < 0).any(dim=2)
-    bounded = i_lt_j.any(dim=0)
-    return ~bounded.cpu().numpy()
+def _compute_bounding_torch(v, device, budget=None):
+    """GPU-accelerated harmonic bounding (single line). Tiled for large S."""
+    S = v.shape[0]
+    if S <= 1:
+        return np.ones(S, dtype=bool)
+    return _compute_bounding_batch_torch(v[None, :, :], device, budget=budget)[0]
 
 
 class LazyParseList:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -251,3 +251,78 @@ def test_entity_path_evaluates_all_constraints():
     df_mass = list(parse_batch_from_df(t._syll_df, m).values())[0]._all_viols.sum(axis=(0, 1))
     assert [int(x) for x in df_mass] == [int(x) for x in ent_mass], \
         "DF and entity paths disagree on constraint totals"
+
+
+def _reference_bounding(viol_sums):
+    """Straightforward, un-tiled harmonic bounding. A scansion j is bounded iff
+    some scansion i dominates it (<= on every constraint, < on at least one).
+    Used as the ground truth the chunked/tiled implementation must match."""
+    import numpy as np
+    L, S, C = viol_sums.shape
+    if S <= 1:
+        return np.ones((L, S), dtype=bool)
+    diff = viol_sums[:, :, None, :] - viol_sums[:, None, :, :]  # (L, S, S, C)
+    i_leq_j = (diff <= 0).all(axis=3)
+    i_lt_j = i_leq_j & (diff < 0).any(axis=3)
+    bounded = i_lt_j.any(axis=1)
+    return ~bounded
+
+
+def test_bounding_tiled_equals_reference():
+    """Memory-budgeted (chunked over L, tiled over S x S) harmonic bounding must
+    return the exact same unbounded mask as the plain O(S^2 C) reference, for
+    inputs of varied L / S / C and at several memory budgets that force real
+    tiling. This guards the C6/F4 optimization: a memory win that changed which
+    parses are bounded would be a silent correctness bug."""
+    import numpy as np
+    from prosodic.parsing import vectorized as V
+
+    rng = np.random.default_rng(12345)
+    dev = V.get_device()
+
+    cases = []
+    # (L, S, C, make_perfect)
+    for L, S, C in [(1, 1, 4), (2, 2, 3), (3, 10, 5), (4, 25, 6),
+                    (2, 40, 4), (3, 64, 7), (1, 128, 8), (5, 30, 5),
+                    (2, 200, 6)]:
+        # non-perfect: shift up by 1 so no all-zero row (forces pairwise path)
+        cases.append((rng.integers(0, 3, size=(L, S, C)) + 1).astype(np.int64))
+        # binary values -> many ties / duplicate rows (dominance edge cases)
+        cases.append(rng.integers(0, 2, size=(L, S, C)).astype(np.int64))
+
+    # a case with duplicate rows (equal vectors must NOT bound each other)
+    dup = (rng.integers(0, 3, size=(2, 50, 4)) + 1).astype(np.int64)
+    dup[:, 1, :] = dup[:, 0, :]
+    dup[:, 7, :] = dup[:, 0, :]
+    cases.append(dup)
+
+    # budgets small enough to force multi-tile / multi-chunk decomposition,
+    # plus the module default (no forced tiling for small S).
+    budgets = [4096, 50_000, 500_000, None]
+
+    for arr in cases:
+        ref = _reference_bounding(arr)
+        for budget in budgets:
+            got = V._compute_bounding_batch_numpy(arr.copy(), budget=budget)
+            assert np.array_equal(ref, got), (
+                f"numpy tiled != reference (shape={arr.shape}, budget={budget})")
+            if dev is not None:
+                got_t = V._compute_bounding_batch_torch(arr.copy(), dev, budget=budget)
+                assert np.array_equal(ref, got_t), (
+                    f"torch tiled != reference (shape={arr.shape}, budget={budget})")
+
+        # single-line entry points must agree with the batch reference too
+        for li in range(arr.shape[0]):
+            v_sc = arr[li]
+            exp = ref[li]
+            got_sl = V._compute_bounding_numpy(v_sc.copy(), budget=4096)
+            assert np.array_equal(exp, got_sl), "single-line numpy tiled mismatch"
+            if dev is not None:
+                got_slt = V._compute_bounding_torch(v_sc.copy(), dev, budget=4096)
+                assert np.array_equal(exp, got_slt), "single-line torch tiled mismatch"
+
+    # block-size helper never exceeds the requested element budget
+    Lc, Ti, Tj = V._bounding_block_sizes(4, 8362, 14, bytes_per_elem=8, budget=V.BOUNDING_MEM_BUDGET)
+    assert Lc * Ti * Tj * 14 * 8 <= V.BOUNDING_MEM_BUDGET
+    # small problems are not tiled (single-shot, identical to the old path)
+    assert V._bounding_block_sizes(3, 20, 6, bytes_per_elem=8) == (3, 20, 20)


### PR DESCRIPTION
## What

Reduce peak memory in the harmonic-bounding step (AUDIT **C6 / F4**).

`compute_bounding_batch` materialized a single `(L, S, S, C)` tensor to compare every scansion against every other for dominance. Near the syllable cap (`S ~ 8000+`) that is **~1 GB (GPU int16) / ~4 GB (numpy int64) per non-perfect line**. The perfect-parse shortcut hid this for typical verse, but prose lineparts at 16–18 syllables rarely parse perfectly, and dense corpora hit it in aggregate.

## How

Chunk the pairwise comparison over the line (`L`) axis and tile the `S × S` plane so the `(Lc, Ti, Tj, C)` diff intermediate stays within a memory budget (`BOUNDING_MEM_BUDGET`, 128 MB). Block sizes are derived from the budget by `_bounding_block_sizes`.

Tiling is a **pure reassociation** of the same per-pair AND/OR dominance reduction: `bounded[l, j]` is the OR over all `i` of "`i` dominates `j`", accumulated over `i`-tiles. So the unbounded mask is **byte-identical** to the untiled computation. When the whole comparison already fits the budget (the common small-`S` case), it runs in a single allocation — identical to the previous code path.

Scope: only `prosodic/parsing/vectorized.py` + one test in `tests/test_parsing.py`.

## Correctness (the whole point)

- **Bounding output byte-identical**: 156 synthetic checks across varied `L/S/C` (incl. perfect-parse lines, no-perfect lines, mixed batches, duplicate rows, binary/tie-heavy values, single-constraint, wide-`C`, `S` up to 3000) — `np.array_equal` on numpy **and** MPS, single-line **and** batch paths. Also verified against an inline untiled reference at several forced-tiny budgets that guarantee real multi-tile/multi-chunk decomposition.
- **End-to-end unchanged**: full Shakespeare sonnet + prose + mixed lines (20 lines) — best-parse `meter_str` and `score` identical before vs after, on both MPS and CPU. (A pre-existing `PYTHONHASHSEED`-dependent tie-break between two equal-score parses on one line was neutralized with a fixed seed; it flips with or without this change.)
- New test `test_bounding_tiled_equals_reference` asserts the chunked/tiled bounding equals a straightforward reference implementation over varied sizes and budgets.

## Measured memory reduction (numpy path, one non-perfect line)

| Input | Before (untiled) | After (tiled) |
|---|---|---|
| S=2500, C=14 | ~763 MB | ~356 MB |
| S=4000, C=14 | ~1953 MB | ~338 MB |

The tiled peak stays roughly flat as `S` grows, while the untiled path scales as `S²`.

## C11 (zone-aware bounding) — intentionally skipped

C11 is a *deliberate* behavior change (dominance on zone-split sums, active only under `zone_weights`) and would require threading the un-summed `(S, N, C)` viols + zones through every bounding call site. That muddies the byte-identical guarantee that is the entire point of this PR, so it is left for a follow-up (AUDIT F9). C6 was the priority and is fully addressed.

## Tests

`tests/test_parsing.py` + `tests/test_v3.py`: **76 passed**. Bounding-adjacent suites (`test_batch`, `test_constraints`, `test_texts`): 25 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n