### PR TITLE
Make pronunciation-variant order deterministic (fixes tie-break flip)

### DIFF
--- a/prosodic/langs/langs.py
+++ b/prosodic/langs/langs.py
@@ -176,7 +176,12 @@ class LanguageModel:
         ##
         sylls_ipa_lt = [tuple(x) for x in sylls_ipa_ll]
         sylls_ipa_ll = [list(x) for x in set(sylls_ipa_lt)]
-        sylls_ipa_ll.sort(key=lambda x: (count_stresses_in_sylls_ipa_l(x), len(x)))
+        # Include the syllable content as a final sort key so pronunciation
+        # variants with equal stress-count and length get a DETERMINISTIC order.
+        # Without it the dedup `set(...)` leaves equal-key variants in
+        # hash-seed-dependent order, which propagates to form_idx and makes the
+        # best-parse tie-break flip across runs on lines with tied scansions.
+        sylls_ipa_ll.sort(key=lambda x: (count_stresses_in_sylls_ipa_l(x), len(x), tuple(x)))
         meta = {
             "force_unstress": force_unstress,
             "force_ambig_stress": force_ambig_stress,

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from prosodic.imports import *
+from prosodic.langs.langs import Language, count_stresses_in_sylls_ipa_l
+
+disable_caching()
+
+
+def test_pronunciation_variant_order_deterministic():
+    """Pronunciation variants must come back in a fully-determined order
+    (including syllable content), so the best-parse tie-break can't flip across
+    runs or PYTHONHASHSEED values.
+
+    Regression: get_sylls_ipa_ll deduped variants through set() and then sorted
+    by (stress_count, len), leaving variants with an equal key in hash-seed
+    order. That propagated to form_idx and made text.parse() return different
+    best scansions across runs on lines with tied-score parses."""
+    lang = Language("en")
+    checked = 0
+    for tok in ["beauty", "desire", "increase", "fire", "heaven", "flower",
+                "being", "power", "hour", "spirit", "even", "many", "towards"]:
+        variants, _ = lang.get_sylls_ipa_ll(tok)
+        if len(variants) < 2:
+            continue
+        keys = [(count_stresses_in_sylls_ipa_l(v), len(v), tuple(v)) for v in variants]
+        assert keys == sorted(keys), \
+            f"{tok!r}: pronunciation variants not in deterministic order: {keys}"
+        checked += 1
+    assert checked > 0, "no multi-variant word found to exercise the ordering"


### PR DESCRIPTION
Fixes a run-to-run nondeterminism in parse results (surfaced during the #102 bounding work and the correctness audit).

## The bug
`get_sylls_ipa_ll` deduped pronunciation variants through `set()` then sorted by `(stress_count, len)`. Variants with an equal key kept the set's hash-seed-dependent order, which propagated to `form_idx`. So on lines with two equal-score best parses, `text.parse()` returned **different best scansions across runs / `PYTHONHASHSEED`**.

Example: *"Beauty's effect with beauty were bereft,"* flipped between `+-+--+-+-+` and `+--+-+-+-+` (both score 2.0).

## Fix
Add the syllable content (`tuple(x)`) as a final sort key so variant order is fully determined.

## Verification
Per-line best parses over 300 Shakespeare lines are now **byte-identical across `PYTHONHASHSEED` in {0,1,7,42,123}** (was 3 distinct outputs). 265 tests pass; adds `test_pronunciation_variant_order_deterministic`.

Scoped to `langs.py` + a new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)