### PR TITLE
CI: fix release tag, propagate secrets to reusable workflow, stop republishing stale docs

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
         - "develop"
+  # AUDIT R10 (2026-07-04): manual-only trigger for the docs gh-pages publish
+  # job below, until docs/ is regenerated for v3 (see the comment on
+  # build-deploy). The `tests` job above still runs on every push to develop.
+  workflow_dispatch:
 
 
 # you need these permissions to publish to GitHub pages
@@ -16,10 +20,22 @@ permissions:
 jobs:
   tests:
     uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
+    secrets: inherit
 
+  # AUDIT R10 (2026-07-04): this job used to run automatically on every push
+  # to `develop` and republish docs/ to gh-pages with `render: false` — i.e.
+  # it re-published the same stale, pre-built v2-era HTML (docs/ last touched
+  # Sep 2024; docs/reference/ still has pages for modules deleted since, like
+  # lexconvert/metricaltree) on every push, giving a false impression the docs
+  # site is current. Regenerating v3 docs is a separate content task (tracked
+  # in AUDIT.md R10) and out of scope here. Until that regeneration happens,
+  # this job is gated to manual dispatch only so CI stops auto-republishing
+  # stale docs. Re-enable the `push` trigger (or fold this back into the
+  # `on:` block above) once docs/ has been regenerated for v3.
   build-deploy:
     runs-on: ubuntu-latest
     needs: [tests]
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/nonreleases.yml
+++ b/.github/workflows/nonreleases.yml
@@ -11,3 +11,4 @@ on:
 jobs:
     tests:
         uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
+        secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   tests:
     uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
+    secrets: inherit
 
   pre-release:
     name: "GitHub Release"
@@ -21,9 +22,11 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "stable"
+          # No automatic_release_tag: omitting it makes the action use the
+          # triggering ref (the pushed vX.Y.Z tag) instead of a rolling tag,
+          # so the GitHub Release matches the version actually pushed.
           prerelease: false
-          title: "Stable Build"
+          title: "Release ${{ github.ref_name }}"
 
   pypi-release:
     name: "PyPI Release"

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   tests:
     uses: "./.github/workflows/unit-tests.yml"  # use the callable tests job to run tests
+    secrets: inherit
 
   # NOTE: the GitHub release + PyPI upload used to live here, gated only on
   # `needs: [tests]` — every push to master published a new PyPI build. That


### PR DESCRIPTION
## Summary

Three small CI/release cleanups from `AUDIT.md` (R10 + release-action / secrets follow-ups). Scope limited strictly to `.github/workflows/` — no source, docs content, or other files touched.

1. **`release.yml` — GitHub Release now tagged after the pushed version, not a rolling `"stable"` tag.**
   `pre-release` used `marvinpinto/action-automatic-releases@latest` with a hardcoded `automatic_release_tag: "stable"`. Since this workflow only fires on `push: tags: v*`, every tag push was clobbering the same `stable` release/tag instead of producing a release for the actual version (e.g. `v3.4.0`). Removed `automatic_release_tag` entirely so the action falls back to the triggering ref (the pushed tag), and updated the release title to `Release ${{ github.ref_name }}`.

2. **`secrets: inherit` added to every `uses: ./.github/workflows/unit-tests.yml` call.**
   `unit-tests.yml` uploads coverage via `codecov/codecov-action@v4` using `token: ${{ secrets.CODECOV_TOKEN }}`. None of its four callers (`release.yml`, `stable-release.yml`, `latest-release.yml`, `nonreleases.yml`) passed secrets through, so `CODECOV_TOKEN` (and anything else the callable workflow might reference) likely never reached it when invoked as a reusable workflow. Added `secrets: inherit` to all four call sites.

3. **`latest-release.yml` — stop auto-republishing stale docs (AUDIT.md R10).**
   The `build-deploy` job published `docs/` (pre-built v2-era pdoc HTML, last touched Sep 2024, includes pages for since-deleted modules like `lexconvert`/`metricaltree`) to `gh-pages` with `render: false` on every push to `develop` — i.e. it kept re-publishing stale content, not regenerating it. Regenerating v3 docs is a separate content task and out of scope here, so the conservative fix is to gate `build-deploy` behind `workflow_dispatch` only (added `workflow_dispatch:` to the `on:` block, `if: github.event_name == 'workflow_dispatch'` on the job), with a comment explaining why and what needs to happen before re-enabling the automatic `push` trigger. The `tests` job still runs on every push to `develop` as before; `docs/` content itself was not touched.

## Test plan

- [x] `.venv/bin/python -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('yaml ok')"` — all 5 workflow files parse.
- [x] `.venv/bin/python -c "import prosodic"` — sanity import still works (untouched by these changes, confirms nothing else broke).
- [x] `git diff` confirms only files under `.github/workflows/` were changed (`latest-release.yml`, `nonreleases.yml`, `release.yml`, `stable-release.yml`); `docs/` content, source, and everything else untouched.
- [ ] Actual CI run on this PR (via `pull_request` trigger in `unit-tests.yml`) will exercise the `secrets: inherit` change indirectly, though the tag-triggered release job and the gh-pages job can only be verified by pushing a `v*` tag / manually dispatching `latest-release.yml` respectively — not exercised here since neither is in scope for this branch.

## Notes / things I want a second look at

- **`automatic_release_tag` semantics**: per `marvinpinto/action-automatic-releases`' documented behavior, omitting `automatic_release_tag` makes it fall back to the ref that triggered the workflow. Since `release.yml` only runs on `push: tags: v*`, that ref is the pushed version tag, so this should produce a release under e.g. `v3.4.0` rather than the rolling `stable` tag. I did not have a way to actually trigger a tag push in this sandboxed task, so this is read from the action's contract, not observed — worth confirming with a real tag push before relying on it for the next release.
- **`secrets: inherit` reusable-workflow scoping**: standard GitHub Actions semantics say `secrets: inherit` passes all of the caller's accessible secrets (repo + org + environment) into the called reusable workflow, which is what `CODECOV_TOKEN` needs. I didn't have access to the repo's actual secrets configuration to confirm `CODECOV_TOKEN` is currently set (AUDIT.md's progress log notes it may still need to be added/rotated per R3 — this PR fixes the propagation path, but if the secret itself isn't configured on the repo, coverage upload will still no-op/fail regardless.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
EOF
)