### PR TITLE
Vectorize the last per-line constraint loops (unres, word_foot)

### DIFF
--- a/prosodic/parsing/constraints.py
+++ b/prosodic/parsing/constraints.py
@@ -223,20 +223,16 @@ def _word_boundary_vectorized(f):
     L, S, N = f["L"], f["S"], f["N"]
     if N < 2:
         return np.zeros((L, S, N), dtype=np.int8)
-    result = np.zeros((L, S, N), dtype=np.int8)
     word_ids = f["word_ids_raw"]  # (L, N) — not broadcast
     pos_ids = f["position_ids"]   # (S, N)
-    # word boundary at position i: word_ids[i] != word_ids[i-1]
-    # foot boundary: position_ids changes
-    for li in range(L):
-        wids = word_ids[li]  # (N,)
-        word_boundary = np.zeros(N, dtype=bool)
-        word_boundary[1:] = wids[1:] != wids[:-1]
-        foot_boundary = np.zeros((S, N), dtype=bool)
-        foot_boundary[:, 1:] = pos_ids[:, 1:] != pos_ids[:, :-1]
-        # violation: word boundary without foot boundary
-        result[li] = (word_boundary[None, :] & ~foot_boundary).astype(np.int8)
-    return result
+    # word boundary (per line): word_ids[j] != word_ids[j-1]
+    word_boundary = np.zeros((L, N), dtype=bool)
+    word_boundary[:, 1:] = word_ids[:, 1:] != word_ids[:, :-1]
+    # foot boundary (per scansion): position_ids changes
+    foot_boundary = np.zeros((S, N), dtype=bool)
+    foot_boundary[:, 1:] = pos_ids[:, 1:] != pos_ids[:, :-1]
+    # violation: word boundary without a coincident foot boundary
+    return (word_boundary[:, None, :] & ~foot_boundary[None, :, :]).astype(np.int8)
 
 @constraint(
     desc="Word boundary should align with foot boundary",

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -677,77 +677,66 @@ def evaluate_constraints_batch(features_list, meter_vals, position_ids, position
         # use vectorized implementation if available
         if cfunc is not None and cfunc.vectorized is not None:
             all_viols[:, :, :, ci] = cfunc.vectorized(features)
-        elif cname in ("unres_within", "unres_across"):
-            # legacy per-line evaluation for word-boundary constraints
-            for li in range(L):
-                feats_i = features_list[li]
-                wi = feats_i["word_ids"][None, :]
-                hi = feats_i["heavy"][None, :]
-                si = feats_i["stressed"][None, :]
-                fi = feats_i["func_word"][None, :]
-                if cname == "unres_within":
-                    _eval_unres_within(all_viols[li], ci, position_ids, position_sizes,
-                                       wi, hi, si, S, N)
-                else:
-                    _eval_unres_across(all_viols[li], ci, position_ids, position_sizes,
-                                        wi, fi, meter_vals, S, N)
+        elif cname == "unres_within":
+            all_viols[:, :, :, ci] = _unres_within_batch(
+                position_ids, position_sizes, word_ids, heavy, stressed)
+        elif cname == "unres_across":
+            all_viols[:, :, :, ci] = _unres_across_batch(
+                position_ids, position_sizes, word_ids, func_word, meter_vals)
 
     return all_viols, constraint_index
 
 
-def _eval_unres_within(viols, ci, position_ids, position_sizes, word_ids, heavy, stressed, S, N):
-    """Evaluate unres_within constraint for all scansions."""
+def _in_multisyll_position(position_ids, position_sizes):
+    """(S, N) bool: syllable j is a 2nd+ syllable sharing a multi-syllable
+    metrical position with syllable j-1 (the site of a resolution violation)."""
+    S, N = position_ids.shape
+    same_pos = np.zeros((S, N), dtype=bool)
+    same_pos[:, 1:] = position_ids[:, 1:] == position_ids[:, :-1]
+    return same_pos & (position_sizes >= 2)
+
+
+def _unres_within_batch(position_ids, position_sizes, word_ids, heavy, stressed):
+    """(L, S, N) int8 unres_within violations, fully vectorized over lines.
+
+    Violation on syllable j iff it resolves within a word (same word_id as j-1)
+    and the first syllable of the position is heavy or unstressed. Byte-identical
+    to the former per-line/per-syllable loop.
+    """
+    S, N = position_ids.shape
+    L = word_ids.shape[0]
     if N < 2:
-        return
-    for j in range(1, N):
-        # is this syllable in a multi-syll position AND same position as previous syll?
-        same_pos = position_ids[:, j] == position_ids[:, j - 1]  # (S,)
-        multi_syll = position_sizes[:, j] >= 2  # (S,)
-        same_word = word_ids[0, j] == word_ids[0, j - 1]  # scalar
-
-        if not same_word:
-            continue  # unres_within only applies within same word
-
-        in_position = same_pos & multi_syll  # (S,)
-        if not in_position.any():
-            continue
-
-        # first syll of position must be light AND stressed, else violation on 2nd syll
-        prev_heavy = heavy[0, j - 1]  # scalar
-        prev_stressed = stressed[0, j - 1]  # scalar
-        if prev_heavy or not prev_stressed:
-            viols[:, j, ci] |= in_position.astype(np.int8)
+        return np.zeros((L, S, N), dtype=np.int8)
+    in_position = _in_multisyll_position(position_ids, position_sizes)  # (S, N)
+    same_word = np.zeros((L, N), dtype=bool)
+    same_word[:, 1:] = word_ids[:, 1:] == word_ids[:, :-1]
+    bad_first = np.zeros((L, N), dtype=bool)  # prev syll heavy OR unstressed
+    bad_first[:, 1:] = heavy[:, :-1].astype(bool) | ~stressed[:, :-1].astype(bool)
+    line_mask = same_word & bad_first  # (L, N)
+    return (in_position[None, :, :] & line_mask[:, None, :]).astype(np.int8)
 
 
-def _eval_unres_across(viols, ci, position_ids, position_sizes, word_ids, func_word, is_strong_pos, S, N):
-    """Evaluate unres_across constraint for all scansions."""
+def _unres_across_batch(position_ids, position_sizes, word_ids, func_word, meter_vals):
+    """(L, S, N) int8 unres_across violations, fully vectorized over lines.
+
+    Violation on syllable j iff it resolves across a word boundary (different
+    word_id from j-1) AND the position is strong OR the two syllables are not
+    both function words. Byte-identical to the former per-line loop.
+    """
+    S, N = position_ids.shape
+    L = word_ids.shape[0]
     if N < 2:
-        return
-    for j in range(1, N):
-        same_pos = position_ids[:, j] == position_ids[:, j - 1]  # (S,)
-        multi_syll = position_sizes[:, j] >= 2  # (S,)
-        diff_word = word_ids[0, j] != word_ids[0, j - 1]  # scalar
-
-        if not diff_word:
-            continue  # unres_across only applies across word boundaries
-
-        in_position = same_pos & multi_syll  # (S,)
-        if not in_position.any():
-            continue
-
-        # violation if: strong position, OR not both function words
-        prev_func = func_word[0, j - 1]  # scalar
-        curr_func = func_word[0, j]  # scalar
-
-        if is_strong_pos.ndim > 0:
-            # strong position always violates for across-word resolution
-            strong_viol = is_strong_pos[:, j]  # (S,)
-            not_both_func = not (prev_func and curr_func)
-            violation = in_position & (strong_viol | not_both_func)
-        else:
-            violation = in_position
-
-        viols[:, j, ci] |= violation.astype(np.int8)
+        return np.zeros((L, S, N), dtype=np.int8)
+    in_position = _in_multisyll_position(position_ids, position_sizes)  # (S, N)
+    diff_word = np.zeros((L, N), dtype=bool)
+    diff_word[:, 1:] = word_ids[:, 1:] != word_ids[:, :-1]
+    fw = func_word.astype(bool)
+    not_both_func = np.zeros((L, N), dtype=bool)
+    not_both_func[:, 1:] = ~(fw[:, :-1] & fw[:, 1:])
+    strong = meter_vals.astype(bool)  # (S, N)
+    viol = in_position[None, :, :] & diff_word[:, None, :] & (
+        strong[None, :, :] | not_both_func[:, None, :])
+    return viol.astype(np.int8)
 
 
 def _get_torch_device():

--- a/tests/test_vectorized_constraints.py
+++ b/tests/test_vectorized_constraints.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from prosodic.imports import *
+import numpy as np
+from prosodic.parsing.vectorized import _unres_within_batch, _unres_across_batch
+from prosodic.parsing.constraints import _word_boundary_vectorized
+
+disable_caching()
+
+
+def _rand_case(rng):
+    S = int(rng.randint(1, 9)); N = int(rng.randint(1, 8)); L = int(rng.randint(1, 5))
+    return dict(
+        position_ids=np.sort(rng.randint(0, max(N, 1), (S, N)), axis=1).astype(np.int32),
+        position_sizes=rng.randint(1, 3, (S, N)).astype(np.int32),
+        word_ids=np.sort(rng.randint(0, max(N, 1), (L, N)), axis=1).astype(np.int32),
+        heavy=rng.randint(0, 2, (L, N)).astype(bool),
+        stressed=rng.randint(0, 2, (L, N)).astype(bool),
+        func_word=rng.randint(0, 2, (L, N)).astype(bool),
+        meter_vals=rng.randint(0, 2, (S, N)).astype(bool),
+        S=S, N=N, L=L,
+    )
+
+
+def test_unres_within_matches_reference():
+    rng = np.random.RandomState(0)
+    for _ in range(40):
+        c = _rand_case(rng); S, N, L = c["S"], c["N"], c["L"]
+        got = _unres_within_batch(c["position_ids"], c["position_sizes"],
+                                  c["word_ids"], c["heavy"], c["stressed"])
+        exp = np.zeros((L, S, N), dtype=np.int8)
+        for l in range(L):
+            for j in range(1, N):
+                for s in range(S):
+                    in_pos = (c["position_ids"][s, j] == c["position_ids"][s, j - 1]
+                              and c["position_sizes"][s, j] >= 2)
+                    if in_pos and c["word_ids"][l, j] == c["word_ids"][l, j - 1] and \
+                            (c["heavy"][l, j - 1] or not c["stressed"][l, j - 1]):
+                        exp[l, s, j] = 1
+        assert np.array_equal(got, exp)
+
+
+def test_unres_across_matches_reference():
+    rng = np.random.RandomState(1)
+    for _ in range(40):
+        c = _rand_case(rng); S, N, L = c["S"], c["N"], c["L"]
+        got = _unres_across_batch(c["position_ids"], c["position_sizes"],
+                                  c["word_ids"], c["func_word"], c["meter_vals"])
+        exp = np.zeros((L, S, N), dtype=np.int8)
+        for l in range(L):
+            for j in range(1, N):
+                for s in range(S):
+                    in_pos = (c["position_ids"][s, j] == c["position_ids"][s, j - 1]
+                              and c["position_sizes"][s, j] >= 2)
+                    diff_word = c["word_ids"][l, j] != c["word_ids"][l, j - 1]
+                    nbf = not (c["func_word"][l, j - 1] and c["func_word"][l, j])
+                    if in_pos and diff_word and (c["meter_vals"][s, j] or nbf):
+                        exp[l, s, j] = 1
+        assert np.array_equal(got, exp)
+
+
+def test_word_foot_matches_reference():
+    rng = np.random.RandomState(2)
+    for _ in range(40):
+        c = _rand_case(rng); S, N, L = c["S"], c["N"], c["L"]
+        f = {"L": L, "S": S, "N": N, "word_ids_raw": c["word_ids"],
+             "position_ids": c["position_ids"]}
+        got = _word_boundary_vectorized(f)
+        exp = np.zeros((L, S, N), dtype=np.int8)
+        for l in range(L):
+            for j in range(1, N):
+                for s in range(S):
+                    wb = c["word_ids"][l, j] != c["word_ids"][l, j - 1]
+                    fb = c["position_ids"][s, j] != c["position_ids"][s, j - 1]
+                    if wb and not fb:
+                        exp[l, s, j] = 1
+        assert np.array_equal(got, exp)


### PR DESCRIPTION
Finishes the vectorization of the parser (AUDIT C18/C19): the last per-line Python loops in constraint evaluation are gone.

## What
- **unres_within / unres_across** (C18) had no vectorized lambda, so `evaluate_constraints_batch` looped over lines calling a per-syllable helper. Replaced with `_unres_within_batch` / `_unres_across_batch`: a `(S,N)` resolution-position mask broadcast against per-line `(L,N)` word/stress masks.
- **word_foot** (C19): its vectorized lambda still had `for li in range(L)`. Dropped it for one `(L,1,N) & (1,S,N)` broadcast.

## Byte-identical
Full violation tensors + best parses hash **identical** before vs after on 400 Shakespeare lines with a 13-constraint meter. New `test_vectorized_constraints.py` checks all three helpers against a scalar reference on random inputs. 92 parsing/v3/constraint tests pass. 2000 Milton lines parse in ~3.2s.

## Deliberately NOT in this PR
- **C11/F9 zone-aware bounding** — real but narrow (only under MaxEnt `zone_weights`), a behavior change touching all 5 bounding call sites, with 0/14 measured conflicts on a fitted sonnet. Disproportionate to the measured benefit; left documented in AUDIT.md.
- **C16/C17 entity constraint reference impls** (no-op clash/lapse/word_foot bodies; `wf1 is wf2`) — affect only manually-constructed Parse objects, not the vectorized parser. Low value vs. re-implementation cost; documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)