### PR TITLE
Fix parse-caching correctness bugs (force / partial-iter / fit invalidation)

### DIFF
--- a/prosodic/parsing/meter.py
+++ b/prosodic/parsing/meter.py
@@ -54,7 +54,22 @@ class Meter(Entity):
     @property
     def key(self):
         if self._key is None:
-            self._key = f"{self.nice_type_name}({encode_hash(serialize(self._attrs))})"
+            # Fold learned zones/zone_weights (set by fit/fit_annotations) into
+            # the key so a fitted meter hashes differently from an unfitted one.
+            # These live as instance attrs (not in _attrs), so without this a
+            # fit() would leave meter.key unchanged and callers keyed on it
+            # (TextModel._parse_results / _line_parse_results) would return
+            # stale, pre-fit parses. (C10)
+            attrs = dict(self._attrs)
+            zones = getattr(self, 'zones', None)
+            zone_weights = getattr(self, 'zone_weights', None)
+            if zones is not None:
+                attrs['zones'] = zones if isinstance(zones, (str, int)) else str(zones)
+            if zone_weights is not None:
+                attrs['zone_weights'] = {
+                    str(k): float(v) for k, v in dict(zone_weights).items()
+                }
+            self._key = f"{self.nice_type_name}({encode_hash(serialize(attrs))})"
         return self._key
 
     def to_dict(self, incl_attrs=True, **kwargs) -> Dict[str, Any]:

--- a/prosodic/texts/texts.py
+++ b/prosodic/texts/texts.py
@@ -266,6 +266,7 @@ class TextModel(Entity):
 
         if combine_by != self.prefix:
             self._parses = ParseListList(parent=self)
+        single = None
         for i,pl in enumerate(self.parse_iter(
             combine_by=combine_by,
             force=force,
@@ -274,10 +275,17 @@ class TextModel(Entity):
             **meter_kwargs,
         )):
             if combine_by == self.prefix:
-                return pl
+                # Single-unit parse (e.g. Line.parse()): keep the first result
+                # but drain the generator so parse_iter runs to completion and
+                # commits the result to the cache (T4 — an early `return pl`
+                # here would abandon the generator before it caches).
+                if single is None:
+                    single = pl
             else:
                 pl._num = i+1
                 self._parses.append(pl)
+        if combine_by == self.prefix:
+            return single
         return self._parses
 
     def parse_iter(
@@ -295,54 +303,85 @@ class TextModel(Entity):
             combine_by = None
 
         parse_key = (meter.key, combine_by)
+
+        # force=True: drop any cached results for this key so this call
+        # actually re-parses instead of replaying the stale cached list.
+        # (T4 / T2 — force was previously a no-op on a cache hit.)
+        # parse_iter is shared with WordTokenList/Line, which has
+        # _parse_results but not the DF-path result caches, so guard those.
+        if force:
+            self._parse_results.pop(parse_key, None)
+            for cache_name in ('_line_parse_results', '_linepart_parse_results'):
+                cache = getattr(self, cache_name, None)
+                if cache is not None:
+                    cache.pop(meter.key, None)
+
+        # _attach_line_parse_results is TextModel-only; parse_iter is shared
+        # with WordTokenList/Line, so resolve it defensively (None if absent).
+        attach = getattr(self, '_attach_line_parse_results', None)
+
         if parse_key in self._parse_results:
             yield from self._parse_results[parse_key]
             # T7: re-attach to already-built line entities (no-op if unbuilt)
-            self._attach_line_parse_results()
-        else:
-            self._parse_results[parse_key] = []
-            last_unit = None
-            units = []
-            for parse_list in meter.parse_text_iter(
-                self, force=force, lim=lim
-            ):
-                # DF-only path: parse_list.parent may be None
-                if parse_list.parent is not None:
-                    parsed_ent = parse_list.parent
-                    parsed_ent._parses = parse_list
-                else:
-                    # DF path: results stored in _line_parse_results,
-                    # will be attached to entities when lines are accessed
-                    parsed_ent = None
+            if attach is not None:
+                attach()
+            return
 
-                if not combine_by:
-                    self._parse_results[parse_key].append(parse_list)
-                    yield parse_list
-                elif parsed_ent is not None:
-                    this_unit = getattr(parsed_ent, combine_by)
-                    if units and last_unit is not this_unit:
-                        new_parselist = ParseList.from_combinations(units, parent=last_unit)
-                        last_unit._parses = new_parselist
-                        self._parse_results[parse_key].append(new_parselist)
-                        yield new_parselist
-                        units = []
-                    units.append(parse_list)
-                    last_unit = this_unit
-                else:
-                    # DF path without combine: just collect
-                    self._parse_results[parse_key].append(parse_list)
-                    yield parse_list
+        # Accumulate into a LOCAL list; only commit to the cache once the
+        # generator is fully consumed (T4). A partially-consumed iterator
+        # (e.g. next(t.parse_iter())) never reaches the commit below, so it
+        # can't poison later parse() calls with a truncated prefix. Limited
+        # runs (lim set) are never cached, since lim is not part of parse_key
+        # and would otherwise truncate the results stored under the full key.
+        results = []
+        last_unit = None
+        units = []
+        for parse_list in meter.parse_text_iter(
+            self, force=force, lim=lim
+        ):
+            # DF-only path: parse_list.parent may be None
+            if parse_list.parent is not None:
+                parsed_ent = parse_list.parent
+                parsed_ent._parses = parse_list
+            else:
+                # DF path: results stored in _line_parse_results,
+                # will be attached to entities when lines are accessed
+                parsed_ent = None
 
-            if units:
-                new_parselist = ParseList.from_combinations(units, parent=last_unit)
-                last_unit._parses = new_parselist
-                self._parse_results[parse_key].append(new_parselist)
-                yield new_parselist
+            if not combine_by:
+                results.append(parse_list)
+                yield parse_list
+            elif parsed_ent is not None:
+                this_unit = getattr(parsed_ent, combine_by)
+                if units and last_unit is not this_unit:
+                    new_parselist = ParseList.from_combinations(units, parent=last_unit)
+                    last_unit._parses = new_parselist
+                    results.append(new_parselist)
+                    yield new_parselist
+                    units = []
+                units.append(parse_list)
+                last_unit = this_unit
+            else:
+                # DF path without combine: just collect
+                results.append(parse_list)
+                yield parse_list
 
-            # T7: attach DF-path results to already-built line entities so
-            # `t.lines; t.parse()` populates line._parses (not just the
-            # pre-access `t.parse(); t.lines` path).
-            self._attach_line_parse_results()
+        if units:
+            new_parselist = ParseList.from_combinations(units, parent=last_unit)
+            last_unit._parses = new_parselist
+            results.append(new_parselist)
+            yield new_parselist
+
+        # Fully consumed (generator ran to completion): safe to cache — but
+        # not for limited runs, which hold only a prefix of the full result.
+        if lim is None:
+            self._parse_results[parse_key] = results
+
+        # T7: attach DF-path results to already-built line entities so
+        # `t.lines; t.parse()` populates line._parses (not just the
+        # pre-access `t.parse(); t.lines` path).
+        if attach is not None:
+            attach()
 
     @property
     def parses(self) -> Any:

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -584,3 +584,61 @@ class TestEdgeCases:
         t = TextModel(sonnet)
         pdf = t.parsed_df
         assert pdf['line_num'].nunique() == 14
+
+
+# --- Parse-cache correctness (force / partial-iter / fit invalidation) ---
+
+class TestParseCache:
+    def test_force_recomputes(self):
+        # force=True must re-parse, not replay the stale cached objects (T4/T2).
+        t = TextModel(sonnet)
+        r0 = t.parse()
+        first0 = r0[0]
+        r1 = t.parse(force=True)
+        first1 = r1[0]
+        assert first0 is not first1  # fresh parse, distinct object
+        assert len(r0) == len(r1) == 14
+
+    def test_partial_iter_does_not_truncate(self):
+        # Consuming only the first item of parse_iter() must not poison the
+        # cache so that a later parse() returns a truncated prefix (T4).
+        t = TextModel(sonnet)
+        g = t.parse_iter()
+        next(g)          # consume just the first line
+        del g
+        assert len(t.parse()) == 14
+
+    def test_lim_does_not_poison_cache(self):
+        # A limited parse_iter run must not be cached under the full key (T4).
+        t = TextModel(sonnet)
+        list(t.parse_iter(lim=3))
+        assert len(list(t.parse_iter())) == 14
+
+    def test_single_line_parse_is_cached(self):
+        # Single-unit parse() (Line.parse) must still cache: two calls with the
+        # same meter config return the same object.
+        line = TextModel("embrace " * 5).line1
+        p1 = line.parse()
+        p2 = line.parse()
+        assert p1 is p2
+        p3 = line.parse(force=True)
+        assert p3 is not p1  # force recomputes even for single-unit
+
+    def test_fit_invalidates_cache(self):
+        # meter.fit() must change meter.key so a re-parse recomputes with the
+        # learned zone weights instead of returning pre-fit results (C10).
+        t = TextModel(sonnet)
+        t.parse()
+        meter = t.get_meter()
+        key_pre = meter.key
+        line_pre = t._line_parse_results[key_pre][1]
+        scores_pre = np.array(line_pre._all_scores).copy()
+
+        meter.fit(t, "wswswswsws", zones=3)
+        assert meter.key != key_pre  # key reflects zones/zone_weights
+
+        t.parse()
+        line_post = t._line_parse_results[meter.key][1]
+        assert line_post is not line_pre  # recomputed, not stale cache
+        scores_post = np.array(line_post._all_scores).copy()
+        assert not np.allclose(scores_pre, scores_post)  # fitted weights applied


### PR DESCRIPTION
Fixes three parse-cache correctness bugs surfaced in `AUDIT.md` (T4, T2, C10). Scope limited to `prosodic/texts/texts.py` and `prosodic/parsing/meter.py` (parselists.py needed no change), plus regression tests.

## 1. `force=True` was a no-op on a cache hit (T4/T2)
`TextModel.parse_iter` returned the cached `_parse_results[parse_key]` without consulting `force`, and `meter.parse_text_iter` ignores `force`. Now `force` drops the cached entry for that key (and the DF-path `_line_parse_results` / `_linepart_parse_results` caches keyed by `meter.key`) so the call actually re-parses.

Repro: `t.parse(); r1 = t.parse(force=True)` — pre-fix `r1[0] is r0[0]` (stale object); post-fix a fresh, distinct parse.

## 2. Partially consuming `parse_iter()` permanently truncated results (T4)
`_parse_results[parse_key]` was created up-front and filled as the generator was consumed, so an early stop (`next(t.parse_iter())`, an aborted SSE stream) left a truncated cached list that every later `parse()` replayed. Also `lim` was not part of `parse_key`, so a limited run could poison the full key.

Fix: accumulate into a **local** list, commit to the cache only once the generator is **fully consumed**; **never cache limited runs** (`lim` set). `parse()` now drains the generator on the single-unit path (`Line.parse()`) instead of returning on the first yield, so single-unit parses still cache while multi-unit partial consumption no longer poisons the cache.

Repro: `next(t.parse_iter()); len(t.parse())` — pre-fix returns 1; post-fix returns all lines.

## 3. `meter.fit()` didn't invalidate cached parses (C10)
`zones` / `zone_weights` are stored as instance attrs (not in `_attrs`), so `meter.key` was unchanged after `fit()`; parse then fit then re-parse returned **pre-fit** results. `Meter.key` now folds `zones`/`zone_weights` into the hash, so a fitted meter has a distinct key and re-parsing recomputes with the learned weights.

Repro: parse, `meter.fit(t, "wswswswsws", zones=3)`, re-parse — pre-fix `_all_scores` unchanged (stale); post-fix scores reflect the fitted zone weights.

## Notes
- `parse_iter` is shared with `WordTokenList`/`Line`, which lack the DF-path caches and `_attach_line_parse_results`; those accesses are guarded (`getattr(..., None)`).
- The only mildly risky change was making `parse()` drain the single-unit generator (needed so the deferred cache-commit runs). Kept conservative: still returns the **first** yielded parse and preserves `Line.parse()` caching identity — covered by `test_single_line_parse_is_cached` and the existing `test_feet` / `test_exhaustive`.

## Tests
Added `TestParseCache` to `tests/test_v3.py` (5 tests). Full suite: **286 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
