### PR TITLE
Zone-aware harmonic bounding (C11): bound in the scoring feature space

### DIFF
--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -169,6 +169,7 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
 
 
     constraint_names = list(meter.constraints.keys())
+    bound_zones = _bounding_zones(meter)  # zone-aware bounding when zone_weights set
 
     for nsylls, line_nums in nsyll_groups.items():
         scansions = meter.get_possible_scansions(nsylls)
@@ -191,7 +192,7 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
             )
             constraint_index = ci
             # all_viols_4d is (L, S, N, C) — sum over N for bounding
-            all_viol_sums = all_viols_4d.sum(axis=2)  # (L, S, C)
+            all_viol_sums = _zone_split_batch(all_viols_4d, bound_zones)
             unbounded_masks = compute_bounding_batch(all_viol_sums)
 
             for i, ln in enumerate(simple_lines):
@@ -246,7 +247,7 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
                 if constraint_index is None:
                     constraint_index = ci
                 same_nsylls_viols = [ambig_viols_4d[i] for i in range(len(same_feats_list))]
-                ambig_viol_sums = ambig_viols_4d.sum(axis=2)  # (L, S, C)
+                ambig_viol_sums = _zone_split_batch(ambig_viols_4d, bound_zones)
                 ambig_masks = compute_bounding_batch(ambig_viol_sums)
                 for i in range(len(same_feats_list)):
                     ambig_unbounded[i] = ambig_masks[i]
@@ -267,7 +268,7 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
                 d_viols_4d, ci2 = evaluate_constraints_batch(
                     d_feats, wmv, wpi, wps, constraint_names
                 )
-                d_viol_sums = d_viols_4d.sum(axis=2)
+                d_viol_sums = _zone_split_batch(d_viols_4d, bound_zones)
                 d_masks = compute_bounding_batch(d_viol_sums)
                 for i, item in enumerate(items):
                     diff_results[id(item)] = (d_viols_4d[i], d_masks[i], wscans,
@@ -384,6 +385,7 @@ def parse_batch(parse_units, meter, syll_df=None):
 
         meter_vals, position_ids, position_sizes = encode_scansions(scansions, nsylls)
         constraint_names = list(meter.constraints.keys())
+        bound_zones = _bounding_zones(meter)  # zone-aware bounding when zone_weights set
 
         # split group into simple (no ambiguity) and ambiguous lines
         simple_lines = []
@@ -407,7 +409,7 @@ def parse_batch(parse_units, meter, syll_df=None):
             )  # (L, S, N, C)
 
             # batch bounding
-            all_viol_sums = all_viols_4d.sum(axis=2)  # (L, S, C)
+            all_viol_sums = _zone_split_batch(all_viols_4d, bound_zones)
             unbounded_masks = compute_bounding_batch(all_viol_sums)  # (L, S)
 
             for i, (idx, wt, feats, sylls) in enumerate(simple_lines):
@@ -435,7 +437,7 @@ def parse_batch(parse_units, meter, syll_df=None):
                     [wfeats], wmv, wpi, wps, constraint_names
                 )
                 wviols = wviols_4d[0]  # (S, N, C)
-                wunb = compute_bounding(wviols, wci)
+                wunb = compute_bounding(wviols, wci, zones=bound_zones)
                 wsylls = wfeats["sylls"]
                 wpl = LazyParseList(
                     wtl, meter, wscans, wviols, wci, wunb, wsylls,
@@ -765,8 +767,51 @@ def get_device():
 get_device()
 
 
-def compute_bounding(viols, constraint_index):
-    """Compute harmonic bounding: mark scansions dominated by others."""
+def _bounding_zones(meter):
+    """Zones to use for harmonic bounding, or None for flat bounding.
+
+    Bounding must operate in the SAME feature space as scoring. Zone-aware
+    scoring (LazyParseList) kicks in only when the meter carries learned
+    zone_weights; otherwise scoring is flat, so bounding stays flat too and the
+    default parser path is unchanged/byte-identical.
+    """
+    zones = getattr(meter, 'zones', None)
+    if zones is not None and getattr(meter, 'zone_weights', None):
+        return zones
+    return None
+
+
+def _zone_split_batch(viols_4d, zones):
+    """(L, S, N, C) -> (L, S, C*Z) zone-summed violation COUNTS.
+
+    Harmonic bounding is dominance on the feature-count vector. With zone
+    weights the feature space is (constraint x zone), so bounding must dominate
+    on the zone-split counts, not the flat per-constraint totals — otherwise a
+    parse whose violations sit in low-weight zones can be flat-dominated (and
+    dropped) even though it's the zone-optimal parse. zones=None returns the
+    flat (L, S, C) sum, identical to the previous bounding input.
+    """
+    if zones is None:
+        return viols_4d.sum(axis=2)
+    from .maxent import zone_boundaries
+    L, S, N, C = viols_4d.shape
+    boundaries = zone_boundaries(zones, N)
+    Z = len(boundaries)
+    out = np.zeros((L, S, C * Z), dtype=np.int64)
+    for z, (start, end) in enumerate(boundaries):
+        out[:, :, z * C:(z + 1) * C] = viols_4d[:, :, start:end, :].sum(axis=2)
+    return out
+
+
+def compute_bounding(viols, constraint_index, zones=None):
+    """Compute harmonic bounding: mark scansions dominated by others.
+
+    With `zones` set, dominance is computed on the zone-split (S, C*Z) counts
+    so it matches zone-aware scoring; otherwise on the flat (S, C) sums.
+    """
+    if zones is not None:
+        from .maxent import zone_split
+        return _bound_viol_sums(zone_split(viols, zones))
     v = viols.sum(axis=1)  # (S, C)
     return _bound_viol_sums(v)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -388,3 +388,39 @@ def test_best_parse_cooptimal_signal():
     assert res[0].best_parse.num_cooptimal == 1
     assert res[1].best_parse.is_tied is True
     assert res[1].best_parse.num_cooptimal >= 2
+
+
+def test_zone_aware_bounding_mechanism():
+    """Flat bounding drops a parse that is optimal under zone weights; zone-aware
+    bounding keeps it. AUDIT C11: harmonic bounding must dominate on the same
+    (constraint x zone) feature space that zone-weighted scoring uses."""
+    import numpy as np
+    from prosodic.parsing.vectorized import compute_bounding_batch, _zone_split_batch
+    viols = np.zeros((1, 2, 4, 1), dtype=np.int8)
+    viols[0, 0, :, 0] = [1, 1, 0, 0]   # P: 2 violations, both in zone 0
+    viols[0, 1, :, 0] = [0, 0, 1, 0]   # Q: 1 violation in zone 1
+    flat = compute_bounding_batch(viols.sum(axis=2))[0]
+    zone = compute_bounding_batch(_zone_split_batch(viols, 2))[0]
+    assert flat.tolist() == [False, True]   # flat: Q dominates P on totals -> P dropped
+    assert zone.tolist() == [True, True]     # zones: neither dominates -> both kept
+
+
+def test_zone_aware_bounding_selects_zone_optimal():
+    """End-to-end: under skewed zone weights, best-parse selection must be the
+    true zone-minimum. With flat bounding this line's zone-optimal parse is
+    dropped and a ~1000-scoring parse is returned instead. AUDIT C11."""
+    import numpy as np
+    from prosodic.parsing.meter import Meter
+    from prosodic.parsing.vectorized import parse_batch_from_df
+    t = TextModel("Despite of wrinkles this thy golden time.")
+    m = Meter()
+    cn = list(m.constraints.keys())
+    m.zones = 2
+    m.zone_weights = {f"{c}_z1": 0.001 for c in cn}
+    m.zone_weights.update({f"{c}_z2": 1000.0 for c in cn})
+    pl = list(parse_batch_from_df(t._syll_df, m).values())[0]
+    best_idx = int(pl._unbounded_indices[pl._scores.argmin()])
+    # the selected best must BE the global zone-minimum (not a flat-unbounded pick)
+    assert pl._all_scores[best_idx] <= pl._all_scores.min() + 1e-9
+    # concretely: the zone-optimal here is far below the flat pick's ~1000
+    assert pl._all_scores.min() < 1.0


### PR DESCRIPTION
Fixes C11 — which I wrongly deferred as "narrow / 0-of-14." It is a real correctness bug on the **default** website MaxEnt-reparse path (the frontend defaults `zones: 3`).

## The bug
Harmonic bounding is Pareto dominance on the violation **feature vector** — and it is (correctly) weight-independent. But zone weights **restructure the feature space**: the `C` constraints become `C·Z` (constraint × position-zone). Scoring moved to `C·Z`; bounding stayed in flat `C`. Flat dominance can drop a parse whose violations sit in low-weight zones even though it is the zone-optimal parse (`flat-unbounded ⊆ zone-unbounded`). So `best_parse`, chosen among the flat-unbounded set, could be badly suboptimal on a zone-fitted reparse.

## The fix
Bound on the zone-split `(S, C·Z)` **counts** when `zone_weights` are active — still weight-independent dominance, just in the same feature space as scoring. `compute_bounding`/`compute_bounding_batch` are column-count-agnostic, so it is a small change at the 5 bounding sites + a `_zone_split_batch` helper. No zone weights → flat → default path unchanged.

## Verification
- **Byte-identical** on the default (no-zone) path (hash-equal on 400 Shakespeare lines).
- **Mechanism** proven with a crafted case (flat drops a zone-optimal parse; zones keep it).
- **Empirical:** across **32 zone/weight configs × 400 lines**, flat bounding picked a non-zone-optimal best on **121 lines** — e.g. *"Despite of wrinkles this thy golden time."* returning a **1000**-scoring parse when a **0.002** parse existed. With the fix: **0**. So the audit's "0/14" was one gentle fit; skewed learned weights trigger it for real.

Adds `test_zone_aware_bounding_mechanism` + `test_zone_aware_bounding_selects_zone_optimal`.

**Separate follow-up (not fixed here):** `best_parse.score` on the Python object still reports the **flat** score; selection and the web display both use the zone-aware `_scores`, so the returned *parse* is correct but its `.score` attribute is flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)