### PR TITLE
Fix cleanup() building the entity tree it frees (T6)

### DIFF
--- a/prosodic/texts/texts.py
+++ b/prosodic/texts/texts.py
@@ -242,10 +242,30 @@ class TextModel(Entity):
         return self._key
 
     def cleanup(self):
+        # Release parse-result caches. _line_parse_results /
+        # _linepart_parse_results hold the large DF-path (S, N, C) numpy
+        # violation arrays; the original cleanup() cleared only
+        # _parse_results and left those pinned (T6).
         self._parse_results.clear()
+        for cache_name in ('_line_parse_results', '_linepart_parse_results'):
+            cache = getattr(self, cache_name, None)
+            if cache is not None:
+                cache.clear()
         self._parses = None
-        for obj in self.iter_all():
-            obj.clear_cached_properties()
+
+        # Clear cached properties — but DON'T build the entity tree just to
+        # free it. On the DF-only batch path (parse() with no entity access)
+        # entities were never constructed; the old code called self.iter_all(),
+        # which accesses the `children` property and triggers _build_children(),
+        # constructing the full word×form×syll×phoneme tree only to clear
+        # caches on it (T6). Guard on _children_built: only walk the tree when
+        # it was actually built. If children were never built there is nothing
+        # below the TextModel to clear, so just clear its own cached properties.
+        if self._children_built:
+            for obj in self.iter_all():
+                obj.clear_cached_properties()
+        else:
+            self.clear_cached_properties()
 
     def __getitem__(self, item):
         if isinstance(item, slice):

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -118,6 +118,45 @@ class TestLazyEntities:
         assert t._children_built is True
 
 
+# --- cleanup() ---
+
+class TestCleanup:
+    def test_cleanup_does_not_build_entities(self):
+        # DF-only parse (no entity access), then cleanup — cleanup must NOT
+        # construct the lazy entity tree just to clear caches (T6).
+        t = TextModel(sonnet)
+        t.parse()
+        assert t._children_built is False
+        t.cleanup()
+        assert t._children_built is False
+
+    def test_cleanup_clears_df_result_caches(self):
+        # cleanup must release the large DF-path numpy violation arrays held
+        # in _line_parse_results / _linepart_parse_results, not just
+        # _parse_results (T6).
+        t = TextModel(sonnet)
+        t.parse()
+        assert len(t._line_parse_results) > 0
+        t.cleanup()
+        assert len(t._parse_results) == 0
+        assert len(t._line_parse_results) == 0
+        assert len(t._linepart_parse_results) == 0
+
+    def test_cleanup_after_entity_build_reparse_works(self):
+        # cleanup after entities were built must not raise, and .lines /
+        # re-parse must still work (lazy rebuild).
+        t = TextModel(sonnet)
+        _ = t.lines
+        assert t._children_built is True
+        t.parse()
+        t.cleanup()
+        # lines rebuild lazily and re-parse succeeds
+        assert len(t.lines) == 14
+        pl = t.parse()
+        assert pl is not None
+        assert len(t._line_parse_results) > 0
+
+
 # --- DF-only parse path ---
 
 class TestDfParsePath:


### PR DESCRIPTION
## T6: `TextModel.cleanup()` builds all the entities it's freeing

`cleanup()` called `self.iter_all()`, which accesses the `children` property and triggers `_build_children()`. On the DF-only batch path (`text.parse()` with no entity access — e.g. `parse_corpus` → `_parse_one` → `t.cleanup()`), this **constructed the full word×form×syll×phoneme tree** just to clear cached properties on it. It also cleared only `_parse_results`, leaving `_line_parse_results` / `_linepart_parse_results` (the large `(S, N, C)` numpy violation arrays) pinned.

### Fix
`cleanup()` now:
- Clears `_line_parse_results` and `_linepart_parse_results` in addition to `_parse_results`.
- Guards the entity-tree walk on `self._children_built`: only walks/clears the tree when it was actually built; otherwise clears just the TextModel's own cached properties, triggering no build.

Subsequent `.lines` / `.parse()` still rebuild lazily as before.

### Before / after (`_children_built` after a DF-only `parse()` + `cleanup()`)
| | before cleanup | after cleanup | `_line_parse_results` cleared |
|---|---|---|---|
| **old** | `False` | `True` (built the tree) | no |
| **new** | `False` | `False` | yes |

### Tests
Added `TestCleanup` in `tests/test_v3.py`:
- `test_cleanup_does_not_build_entities` — DF-only parse + cleanup leaves `_children_built is False`
- `test_cleanup_clears_df_result_caches` — all three result caches emptied
- `test_cleanup_after_entity_build_reparse_works` — build → parse → cleanup → `.lines` + re-parse still work

`pytest tests/test_v3.py tests/test_texts.py tests/test_parsing.py` → **97 passed**.

Scope: only `prosodic/texts/texts.py` (fix) and `tests/test_v3.py` (regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
