### PR TITLE
Dead-code removal + tiny fixes (C14/D4, T12, C20)

### DIFF
--- a/prosodic/langs/langs.py
+++ b/prosodic/langs/langs.py
@@ -364,20 +364,6 @@ def stress_sylls_ipa_l(ipa_l):
     return [stress(syllipa, primary=not i) for i, syllipa in enumerate(ipa_l)]
 
 
-#     if any(get_stress(syllipa) != "U" for ipa in ipa_ll for syllipa in ipa):
-#         ipa_ll.append([unstress(syllipa) for syllipa in ipa_ll[0]])
-#     else:
-#         ipa_ll.append(
-#             [stress(syllipa, primary=not i) for i, syllipa in enumerate(ipa_ll[0])]
-#         )
-#     ipa_ll = [tuple(x) for x in ipa_ll]
-#     ipa_ll = [list(x) for x in set(ipa_ll)]
-#     ipa_ll.sort(
-#         key=lambda ipal: sum(int(get_stress(syllipa) != "U") for syllipa in ipal)
-#     )
-#     return ipa_ll
-
-
 def count_stresses_in_sylls_ipa_l(sylls_ipa_l):
     return sum(bool(get_syll_ipa_stress(syllipa) != "U") for syllipa in sylls_ipa_l)
 
@@ -432,44 +418,6 @@ def get_sylls_ll(sylls_ipa_ll, sylls_text_ll):
 
 def unstress_sylls_ipa_l(sylls_ipa_l):
     return [unstress(syllipa) for syllipa in sylls_ipa_l]
-
-
-# def maybestress(sylls_ll):
-#     sylls_ipa_ll,sylls_text_ll=zip(*sylls_ll)
-#     if sylls_ipa_ll_has_unstress(sylls_ipa_ll) and sylls_ipa_ll_has_stress(sylls_ipa_ll):
-#         return sylls_ll
-
-#     if not sylls_ipa_ll_has_unstress(sylls_ipa_ll):
-#         unstressed_syll_ipa_l = [unstress_sylls_ipa_l
-#         new_syll = ()
-#         sylls_ll.insert(0,)
-
-
-#     # for sylls_text,sylls_ipa in sylls_ll:
-#         # if
-#     if any(get_stress(syllipa) != "U" for ipa in ipa_ll for syllipa in ipa):
-#         ipa_ll.append([unstress(syllipa) for syllipa in ipa_ll[0]])
-#     else:
-#         ipa_ll.append(
-#             [stress(syllipa, primary=not i) for i, syllipa in enumerate(ipa_ll[0])]
-#         )
-#     ipa_ll = [tuple(x) for x in ipa_ll]
-#     ipa_ll = [list(x) for x in set(ipa_ll)]
-#     ipa_ll.sort(
-#         key=lambda ipal: sum(int(get_stress(syllipa) != "U") for syllipa in ipal)
-#     )
-#     return ipa_ll
-
-# def ensure_unstressed(ipa_ll):
-#     if not ipa_ll: return []
-#     ipa_l = ipa_ll[0]
-#     return [unstress(ipa_l)]
-
-
-# def ensure_unstressed(ipa_ll):
-#     if not ipa_ll: return []
-#     ipa_l = ipa_ll[0]
-#     return [unstress(ipa_l)]
 
 
 def get_espeak_error_msg(paths):

--- a/prosodic/parsing/maxent.py
+++ b/prosodic/parsing/maxent.py
@@ -265,12 +265,18 @@ class MaxEntTrainer:
             unique_texts = df["text"].unique().tolist()
             results, line_texts = self._parse_text(unique_texts, lang=lang)
 
-        # build scansion_map: {text: [(scansion, frequency), ...]}
-        scansion_map = {}
+        # build scansion_map: {text: [(scansion, frequency), ...]}. A repeated
+        # (text, scansion) pair accumulates its frequency instead of adding a
+        # duplicate entry (which would otherwise just overwrite `observed[j]`
+        # in _build_line_data rather than summing).
+        scansion_freqs = {}
         for _, row in df.iterrows():
-            scansion_map.setdefault(row["text"], []).append(
-                (row["scansion"], row["frequency"])
-            )
+            key = (row["text"], row["scansion"])
+            scansion_freqs[key] = scansion_freqs.get(key, 0) + row["frequency"]
+
+        scansion_map = {}
+        for (text_, scansion), freq in scansion_freqs.items():
+            scansion_map.setdefault(text_, []).append((scansion, freq))
 
         self._build_line_data(results, line_texts, scansion_map)
 

--- a/prosodic/parsing/meter.py
+++ b/prosodic/parsing/meter.py
@@ -6,7 +6,6 @@ from ..texts import TextModel, Line, Stanza
 from .parselists import ParseList
 from .utils import *
 
-NUM_GOING = 0
 DEFAULT_METER_KWARGS = dict(
     constraints=DEFAULT_CONSTRAINTS,
     max_s=METER_MAX_S,
@@ -94,13 +93,6 @@ class Meter(Entity):
             for cname, cfunc in self.constraint_funcs.items()
             if cfunc.scope == "position"
         }
-
-    def get_pos_types(self, nsylls: Optional[int] = None) -> List[str]:
-        max_w = nsylls if self.max_w is None else self.max_w
-        max_s = nsylls if self.max_s is None else self.max_s
-        wtypes = ["w" * n for n in range(1, max_w + 1)]
-        stypes = ["s" * n for n in range(1, max_s + 1)]
-        return wtypes + stypes
 
     def get_possible_scansions(self, nsylls: int):
         return get_possible_scansions(nsylls, max_s=self.max_s, max_w=self.max_w)

--- a/prosodic/words/wordtokenlist.py
+++ b/prosodic/words/wordtokenlist.py
@@ -133,27 +133,10 @@ class WordTokenList(EntityList):
         """
         from ..texts import TextModel
         return TextModel.parse(self, *args, **kwargs)
-        # from ..parsing.parselists import ParseList
-        # self._parses = ParseList.from_combinations(
-        #     self.parse_iter(
-        #         num_proc=num_proc,
-        #         force=force,
-        #         meter=meter,
-        #         **meter_kwargs,
-        #     ),
-        #     parent=self
-        # )
-        # return self._parses
 
     def parse_iter(self, *args, **kwargs):
         from ..texts import TextModel
         yield from TextModel.parse_iter(self, *args, **kwargs)
-        # meter = self.get_meter(meter=meter, **meter_kwargs)
-        # for parse_list in meter.parse_text_iter(self, num_proc=num_proc, force=force):
-        #     parsed_ent = self.match(parse_list.parent, parse_list.parse_unit)
-        #     parse_list.parent = parsed_ent
-        #     parsed_ent._parses = parse_list
-        #     yield parse_list
 
     def render(
         self, as_str: bool = False, blockquote: bool = False, **meter_kwargs
@@ -225,22 +208,6 @@ class WordTokenList(EntityList):
             Any: The HTML representation of the parsed text.
         """
         return self.parses.to_html(as_str=as_str, blockquote=blockquote)
-
-    # def get_rhyming_lines(self, max_dist: int = RHYME_MAX_DIST) -> Dict[Any, Any]:
-    #     """
-    #     Get rhyming lines from the text.
-
-    #     Args:
-    #         max_dist (int): Maximum distance for rhyme detection. Default is RHYME_MAX_DIST.
-
-    #     Returns:
-    #         Dict[Any, Any]: A dictionary of rhyming lines.
-    #     """
-    #     return dict(
-    #         x
-    #         for st in self.children
-    #         for x in st.get_rhyming_lines(max_dist=max_dist).items()
-    #     )
 
     @property
     def rhyming_lines(self) -> Dict[Any, Any]:

--- a/prosodic/words/wordtype.py
+++ b/prosodic/words/wordtype.py
@@ -82,10 +82,6 @@ class WordType(Entity):
             self.clear_cached_properties()
 
     @property
-    def wtoken(self) -> "WordToken":
-        return WordToken(self.txt, lang=self.lang, children=self.children)
-
-    @property
     def forms(self) -> List["WordForm"]:
         return self.children
 


### PR DESCRIPTION
## Summary

Small, strictly-scoped cleanup from AUDIT.md findings C14, D4, T12, and the MaxEnt part of C20. Only touches: prosodic/parsing/meter.py, prosodic/langs/langs.py, prosodic/words/wordtokenlist.py, prosodic/words/wordtype.py, prosodic/parsing/maxent.py.

- **C14/D4 dead code**
  - meter.py: removed `Meter.get_pos_types` and the unused `NUM_GOING = 0` constant. Grep-confirmed no callers anywhere in prosodic/ or tests/ besides their own definitions.
  - langs.py: removed large commented-out dead code blocks (a half-written duplicate of `stress_sylls_ipa_l`'s body, a commented `maybestress()` function, and two duplicate commented-out `ensure_unstressed()` stubs). Active espeak-discovery logic and `_ESPEAK_IPA_NORMALIZATIONS` are untouched.
  - wordtokenlist.py: removed commented-out dead code trailing `parse()`/`parse_iter()`, and a fully commented-out duplicate `get_rhyming_lines` (the real implementations live in lines.py, stanzas.py, and texts.py, confirmed via grep).
- **T12**: removed `WordType.wtoken` -- grep-confirmed zero callers (the `wtoken` hits in tests/test_ents.py are an unrelated local variable name, not attribute access), and it was buggy: it passed `children=self.children` into `WordToken(...)`, whose `__init__` re-parents the list and steals it away from the WordType.
- **C20 (MaxEnt part)**: `MaxEntTrainer.load_annotations` built `scansion_map` by appending every (text, scansion) annotation row as a separate list entry via `scansion_map.setdefault(...).append(...)`. A repeated (text, scansion) pair (e.g. two annotators agreeing, or a re-annotated line) became a duplicate entry, and downstream in `_build_line_data` the assignment `observed[j] = freq` overwrote rather than summed it, silently dropping frequency data. Now frequencies for the same (text, scansion) pair are accumulated (summed) before the map is built.

## Test plan

- [x] `import prosodic` succeeds from the modified tree.
- [x] `pytest tests/ -q -k "not browser and not slow and not multiproc" --ignore=tests/test_web.py` -> 279 passed, 1 skipped, 1 deselected.
- [x] grep-verified zero remaining references to `NUM_GOING`, `get_pos_types`, `WordType.wtoken`.
- [x] Manual repro of the maxent fix: duplicate (text, scansion) rows now accumulate to a single summed-frequency entry instead of two separate ones.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n
