### PR TITLE
F7: session-consistent pronunciation cache

### DIFF
--- a/prosodic/langs/langs.py
+++ b/prosodic/langs/langs.py
@@ -93,28 +93,89 @@ class LanguageModel:
     @cached_property
     def token2ipa(self):
         d = {}
+        # `seen` dedupes exact (token, pronunciation) rows across BOTH the main
+        # dictionary and the user cache, so a repeated append never yields a
+        # duplicate pronunciation variant in memory (first-wins).
+        seen = set()
         # load main pronunciation dictionary
         if self.path_token2ipa:
-            d = self._load_token2ipa_file(self.path_token2ipa, d)
+            d = self._load_token2ipa_file(self.path_token2ipa, d, seen)
         # load user-local TTS cache
         cache_path = self.path_token2ipa_cache
         if cache_path and os.path.exists(cache_path):
-            d = self._load_token2ipa_file(cache_path, d)
+            # collapse any duplicate rows that accumulated on disk across runs
+            # or parallel processes before loading (keeps the file from growing
+            # unbounded).
+            self._dedupe_cache_file()
+            d = self._load_token2ipa_file(cache_path, d, seen)
         return d
 
-    def _load_token2ipa_file(self, path, d=None):
+    def _load_token2ipa_file(self, path, d=None, seen=None):
         if d is None:
             d = {}
+        if seen is None:
+            seen = set()
         sep = self.pronunciation_dictionary_filename_sep
         with open(path, encoding="utf-8") as f:
             for ln in f:
                 ln = ln.strip()
                 if ln and sep in ln:
                     token, ipa = ln.split(sep, 1)
+                    # skip exact-duplicate (token, pronunciation) rows; distinct
+                    # pronunciation variants of the same token are still kept.
+                    key = (token, ipa)
+                    if key in seen:
+                        continue
+                    seen.add(key)
                     if token not in d:
                         d[token] = []
                     d[token].append(ipa.split("."))
         return d
+
+    def _dedupe_cache_file(self):
+        """Collapse exact-duplicate rows in the user-local TTS cache on disk.
+
+        The same word can be appended more than once across runs or across
+        parallel processes (each holds its own in-memory map), so the cache
+        file grows unbounded. This rewrites it (atomically) keeping the first
+        occurrence of each row -- but only when duplicates are actually found,
+        so the common no-dupes case does no writes. Best-effort: dedupe on disk
+        is an optimization, never a correctness requirement.
+        """
+        cache_path = self.path_token2ipa_cache
+        if not cache_path or not os.path.exists(cache_path):
+            return
+        sep = self.pronunciation_dictionary_filename_sep
+        seen = set()
+        unique = []
+        n_rows = 0
+        try:
+            with open(cache_path, encoding="utf-8") as f:
+                for ln in f:
+                    stripped = ln.strip()
+                    if not stripped or sep not in stripped:
+                        continue
+                    n_rows += 1
+                    if stripped in seen:
+                        continue
+                    seen.add(stripped)
+                    unique.append(stripped)
+        except OSError:
+            return
+        if len(unique) == n_rows:
+            return  # no duplicates -- leave the file untouched
+        tmp_path = cache_path + ".tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                for stripped in unique:
+                    f.write(stripped + "\n")
+            os.replace(tmp_path, cache_path)
+        except OSError:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
 
     def _cache_tts_result(self, token, sylls_ipa_l):
         """Append a TTS pronunciation result to the user-local cache file."""
@@ -154,6 +215,13 @@ class LanguageModel:
                 # cache TTS result to disk for next startup
                 for sylls_ipa_l in sylls_ipa_ll:
                     self._cache_tts_result(token, sylls_ipa_l)
+                # ...and into the in-memory map, so a repeat lookup of this
+                # token this session resolves from the dict and never re-hits
+                # espeak -- even for a different force_unstress/force_ambig_stress
+                # argument, which is a distinct get_sylls_ipa_ll cache key. Store
+                # the RAW (pre-format, pre-stress-mod) pronunciation so it matches
+                # exactly what a fresh disk load would produce.
+                self.token2ipa[token] = [list(s) for s in sylls_ipa_ll]
             else:
                 log.error(f'cannot parse syll IPAs in {token}')
                 meta['ipa_origin'] = 'error'

--- a/tests/test_langs.py
+++ b/tests/test_langs.py
@@ -232,6 +232,81 @@ def test_every_syllable_has_a_vowel():
             )
 
 
+def test_tts_cache_dedup_on_load(tmp_path):
+    """A user-local TTS cache that accumulated duplicate rows (across runs or
+    parallel processes) collapses to one entry per (token, pronunciation) on
+    load, keeping distinct pronunciation variants -- and the file is rewritten
+    without the dupes so it does not grow unbounded."""
+    from prosodic.langs.langs import LanguageModel
+    cache_file = tmp_path / "en_cache.tsv"
+    cache_file.write_text(
+        "foobarbaz\t'fu.baɹ.baz\n"
+        "foobarbaz\t'fu.baɹ.baz\n"   # exact duplicate -> collapse
+        "foobarbaz\tfu.'baɹ.baz\n"   # distinct variant  -> keep
+        "quuxword\t'kwʌks\n"
+        "quuxword\t'kwʌks\n",        # exact duplicate -> collapse
+        encoding="utf-8",
+    )
+
+    class _CacheLang(LanguageModel):
+        # name=None -> no main dictionary; only the cache below is loaded
+        @property
+        def path_token2ipa_cache(self):
+            return str(cache_file)
+
+    lang = _CacheLang()
+    d = lang.token2ipa
+    # exact-duplicate rows collapsed, distinct variant retained
+    assert d["foobarbaz"] == [["'fu", "baɹ", "baz"], ["fu", "'baɹ", "baz"]]
+    assert d["quuxword"] == [["'kwʌks"]]
+    # the on-disk cache was rewritten without the duplicate rows
+    lines = [l for l in cache_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 3
+    assert lines.count("quuxword\t'kwʌks") == 1
+    assert lines.count("foobarbaz\t'fu.baɹ.baz") == 1
+
+
+def test_tts_hit_updates_inmemory_map_single_espeak(tmp_path):
+    """After a TTS (espeak) hit, the pronunciation is inserted into the
+    in-memory map, so a second lookup of the same token this session -- even
+    with a different force arg (a distinct get_sylls_ipa_ll cache key) -- is
+    served from the dict and does NOT re-invoke the TTS/espeak path."""
+    from prosodic.langs.langs import LanguageModel
+    cache_file = tmp_path / "english_cache.tsv"
+
+    class _CountingLang(LanguageModel):
+        def __init__(self, cache_path):
+            self._cache_path = cache_path
+            self.tts_calls = 0
+
+        @property
+        def path_token2ipa_cache(self):
+            return self._cache_path
+
+        # stand in for the espeak/TTS path (get_sylls_ipa_ll_tts is what would
+        # invoke the phonemizer); count invocations, return a canned result.
+        def get_sylls_ipa_ll_tts(self, token):
+            self.tts_calls += 1
+            return [["'hɛ", "loʊ"]]
+
+    lang = _CountingLang(str(cache_file))
+
+    r1 = lang.get_sylls_ipa_ll("helloword")
+    assert r1
+    assert lang.tts_calls == 1
+    # the token is now in the in-memory map...
+    assert "helloword" in lang.token2ipa
+    assert lang.get_sylls_ipa_ll_dict("helloword")
+    # ...and written to disk for the next session
+    assert cache_file.exists()
+
+    # second lookup with a DIFFERENT force arg -> distinct lru_cache key, so the
+    # method body runs again, but it must resolve from the dict, not re-TTS.
+    r2 = lang.get_sylls_ipa_ll("helloword", force_unstress=True)
+    assert r2
+    assert lang.tts_calls == 1
+
+
 def test_stresses():
     # Test sylls_ipa_l_has_stress
     assert sylls_ipa_l_has_stress(["'maɪ"])


### PR DESCRIPTION
## What

Three caching fixes to the English TTS/espeak path in `prosodic/langs/langs.py` so pronunciation caching is session-consistent (AUDIT F7).

### 1. In-memory update after a TTS hit
After espeak phonemizes a word, the **raw** pronunciation is now inserted into the in-memory `token2ipa` map — previously it was only appended to disk. A second lookup of the same token this session (including with a different `force_unstress`/`force_ambig_stress` arg, which is a distinct `get_sylls_ipa_ll` lru_cache key) now resolves from the dict and never re-invokes espeak.

**Verified end-to-end** by wrapping the real `phonemizer.phonemize`: two same-word lookups (different force args) call it **exactly once**.

### 2. Disk cache dedup on load
`~/prosodic_data/data/{lang}_cache.tsv` accumulated duplicate rows across runs and parallel processes. The real `english_cache.tsv` was 50% bloat — **10533 rows, 5247 unique**. `token2ipa` now dedupes exact `(token, pronunciation)` rows on load (**first-wins**, distinct pronunciation variants retained) and rewrites the file **atomically** (`os.replace`) only when dupes are found — no writes in the clean case. TSV format preserved; cold→warm behavior unchanged. Running the suite deduped the real cache 10533 → 5247 rows, 0 leftover `.tmp`.

### 3. Unbounded caches (from #89) — confirmed, not regressed
`get_word`, `get_sylls_ipa_ll`, `get_sylls_text_l`, `syllabify_ipa` are already `@cache(maxsize=None)`. Left as-is.

## Tests
Two regression tests added to `tests/test_langs.py`:
- `test_tts_cache_dedup_on_load` — duplicate rows collapse to one entry per variant, distinct variants kept, file rewritten without dupes.
- `test_tts_hit_updates_inmemory_map_single_espeak` — after a TTS hit the token is in the in-memory map; a second lookup with a different force arg does not re-hit the TTS path.

`.venv/bin/python -m pytest tests/test_langs.py tests/test_v3.py` → **82 passed**. espeak-discovery tests (#109) untouched and passing.

## Scope
Only `prosodic/langs/langs.py` + `tests/test_langs.py`. No changes to pronunciations, only caching. Did not touch vectorized.py, texts.py, constraints.py, or web/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C63RMzHkHfPvHqsPdWMF6n