### PR TITLE
README: clean the notebook→markdown flow (no jupyter/pandas junk)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,14 @@ cd prosodic/web/frontend && npm run build               # build to ../static_bui
 yapf --style .style.yapf -i <file>
 
 # Rebuild README.ipynb + README.md (after API or analysis-module changes)
-.venv/bin/python scripts/build_readme.py            # executes cells, writes README.ipynb
-.venv/bin/jupyter nbconvert --to markdown README.ipynb --output README
+.venv/bin/python scripts/build_readme.py            # executes cells → README.ipynb AND clean README.md
+#   (requires: pip install nbconvert nbclient)
 
 # Recalibrate rhyme threshold against Walker (1775)
 .venv/bin/python scripts/rime_eval.py               # ROC, AUC, suggested max_dist
 ```
 
-The notebook (and the markdown derived from it) is canonical: edit `scripts/build_readme.py`, not `README.ipynb` directly. nbformat regenerates cell UUIDs on every run, so a fresh build will always produce a UUID-only diff — discard it unless content actually changed.
+`scripts/build_readme.py` is the single source: it executes the cells, writes `README.ipynb` (canonical, Colab-runnable), then converts to a clean `README.md` in the same run — no separate `nbconvert` step. The conversion drops the Colab-only bootstrap cell (tagged `remove_cell`), strips pandas `<style>` blocks, and round-trips DataFrame `<table>` HTML into GitHub-native markdown tables, so `README.md` stays HTML-free. Edit `build_readme.py`, not `README.ipynb` directly. nbformat regenerates cell UUIDs on every run, so a fresh build always produces a UUID-only `.ipynb` diff — discard it unless content actually changed.
 
 ## Architecture
 

--- a/README.ipynb
+++ b/README.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "56c3a25f",
+   "id": "feceff09",
    "metadata": {},
    "source": [
     "# Prosodic 3\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f217dd0",
+   "id": "49d43b40",
    "metadata": {},
    "source": [
     "## Install\n",
@@ -40,8 +40,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d27e83a7",
-   "metadata": {},
+   "id": "44a229a2",
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "source": [
     "### Setup (Colab only)\n",
     "\n",
@@ -51,14 +55,17 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6dd7b62f",
+   "id": "7051736c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:11.548764Z",
-     "iopub.status.busy": "2026-05-04T17:58:11.548642Z",
-     "iopub.status.idle": "2026-05-04T17:58:11.554093Z",
-     "shell.execute_reply": "2026-05-04T17:58:11.553449Z"
-    }
+     "iopub.execute_input": "2026-07-04T19:07:00.909982Z",
+     "iopub.status.busy": "2026-07-04T19:07:00.909739Z",
+     "iopub.status.idle": "2026-07-04T19:07:00.917315Z",
+     "shell.execute_reply": "2026-07-04T19:07:00.916937Z"
+    },
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -89,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82d7f617",
+   "id": "37857090",
    "metadata": {},
    "source": [
     "## Quickstart\n",
@@ -100,13 +107,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6a8a4c38",
+   "id": "b8974771",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:11.555519Z",
-     "iopub.status.busy": "2026-05-04T17:58:11.555403Z",
-     "iopub.status.idle": "2026-05-04T17:58:13.179543Z",
-     "shell.execute_reply": "2026-05-04T17:58:13.179078Z"
+     "iopub.execute_input": "2026-07-04T19:07:00.919220Z",
+     "iopub.status.busy": "2026-07-04T19:07:00.919049Z",
+     "iopub.status.idle": "2026-07-04T19:07:03.046495Z",
+     "shell.execute_reply": "2026-07-04T19:07:03.046017Z"
     }
    },
    "outputs": [
@@ -116,18 +123,18 @@
      "text": [
       "  #st    #ln  parse        rhyme      #feet    #syll    #parse\n",
       "-----  -----  -----------  -------  -------  -------  --------\n",
-      "    1      1  -+-+-+-+-+   a              5       10         2\n",
+      "    1      1  -+-+-+-+-+   a              5       10         1\n",
       "    1      2  -+-+-+-+-+   b              5       10         1\n",
       "    1      3  -+-+-+-+-+   a              5       10         3\n",
       "    1      4  -+-+-+-+-+   b              5       10         1\n",
-      "    1      5  -+-+-+-+-+   -              5       10         8\n",
+      "    1      5  -+-+-+-+-+   -              5       10         4\n",
       "    1      6  -+-+-+-+-+   c              5       10         1\n",
-      "    1      7  -+--++-+-+   -              4       10         8\n",
+      "    1      7  -+--++-+-+   -              4       10         6\n",
       "    1      8  +-+-+-+-+-+  c              6       11         2\n",
       "    1      9  -+-+-+-+--   -              4       10         3\n",
       "    1     10  -+-+-+-+--   d              4       10         6\n",
       "    1     11  -+-+-+-+-+   e              5       10         2\n",
-      "    1     12  -+-+-+-+-+   d              5       10         2\n",
+      "    1     12  -+-+-+-+-+   d              5       10         1\n",
       "    1     13  -+-+-+-+-+   e              5       10         2\n",
       "    1     14  -+-+-+-+-+   e              5       10         3\n",
       "\n",
@@ -165,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1601ba9",
+   "id": "b88c2aef",
    "metadata": {},
    "source": [
     "## Reading texts\n",
@@ -176,13 +183,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5a2cedba",
+   "id": "d125158a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:13.180671Z",
-     "iopub.status.busy": "2026-05-04T17:58:13.180549Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.311585Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.311080Z"
+     "iopub.execute_input": "2026-07-04T19:07:03.048220Z",
+     "iopub.status.busy": "2026-07-04T19:07:03.048040Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.687847Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.687498Z"
     }
    },
    "outputs": [
@@ -198,7 +205,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:   0%|          | 0/20307 [00:00<?, ?it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:   0%|          | 0/20307 [00:00<?, ?it/s]"
      ]
     },
     {
@@ -206,7 +213,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:  16%|█▌        | 3167/20307 [00:00<00:00, 24475.44it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:   8%|▊         | 1634/20307 [00:00<00:01, 9792.06it/s]"
      ]
     },
     {
@@ -214,7 +221,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:  35%|███▍      | 7015/20307 [00:00<00:00, 31822.63it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  19%|█▉        | 3853/20307 [00:00<00:01, 15508.92it/s]"
      ]
     },
     {
@@ -222,7 +229,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:  51%|█████     | 10287/20307 [00:00<00:00, 28739.40it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  30%|███       | 6103/20307 [00:00<00:00, 18285.35it/s]"
      ]
     },
     {
@@ -230,7 +237,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:  70%|██████▉   | 14152/20307 [00:00<00:00, 32236.26it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  40%|███▉      | 8059/20307 [00:00<00:00, 14569.55it/s]"
      ]
     },
     {
@@ -238,7 +245,39 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "\u001b[32m[1.93s] Building long text\u001b[0m:  86%|████████▌ | 17459/20307 [00:00<00:00, 28657.85it/s]"
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  51%|█████     | 10304/20307 [00:00<00:00, 16827.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  62%|██████▏   | 12536/20307 [00:00<00:00, 18421.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  71%|███████▏  | 14511/20307 [00:00<00:00, 14750.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  82%|████████▏ | 16753/20307 [00:01<00:00, 16646.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "\u001b[32m[1.79s] Building long text\u001b[0m:  94%|█████████▍| 19082/20307 [00:01<00:00, 18379.62it/s]"
      ]
     },
     {
@@ -282,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b04a76e1",
+   "id": "3998bf8f",
    "metadata": {},
    "source": [
     "## The hierarchy: stanzas → lines → words → syllables → phonemes\n",
@@ -293,13 +332,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "301f47ba",
+   "id": "8f91fd39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.312383Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.312323Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.314426Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.314058Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.689418Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.689287Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.691471Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.691177Z"
     }
    },
    "outputs": [
@@ -323,13 +362,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "bf4f6c3c",
+   "id": "4b236ea8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.315141Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.315089Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.335076Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.334621Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.693005Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.692884Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.706997Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.706692Z"
     }
    },
    "outputs": [
@@ -523,13 +562,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "48ea3300",
+   "id": "a605d588",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.335994Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.335935Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.337949Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.337662Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.708537Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.708416Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.711037Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.710749Z"
     }
    },
    "outputs": [
@@ -556,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2eb01f2e",
+   "id": "dad67a2b",
    "metadata": {},
    "source": [
     "## DataFrame view\n",
@@ -567,13 +606,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a23608ff",
+   "id": "a6414661",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.338813Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.338764Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.343635Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.343284Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.712451Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.712341Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.717800Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.717559Z"
     }
    },
    "outputs": [
@@ -826,13 +865,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "90d80594",
+   "id": "f0db7d01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.344385Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.344344Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.346031Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.345759Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.719110Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.719029Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.721278Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.720986Z"
     }
    },
    "outputs": [
@@ -871,7 +910,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0d2c732",
+   "id": "6b8edba7",
    "metadata": {},
    "source": [
     "## Metrical parsing\n",
@@ -882,13 +921,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "6f189a1a",
+   "id": "dc41a9b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.346675Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.346633Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.354242Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.353889Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.722609Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.722493Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.748525Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.748264Z"
     }
    },
    "outputs": [
@@ -910,13 +949,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "af3decfb",
+   "id": "987f1360",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.355137Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.355085Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.357586Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.357234Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.750020Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.749927Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.752504Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.752236Z"
     }
    },
    "outputs": [
@@ -947,13 +986,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ef2dd722",
+   "id": "fae9a189",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.358491Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.358434Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.359884Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.359604Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.753905Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.753806Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.755551Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.755281Z"
     }
    },
    "outputs": [
@@ -974,13 +1013,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c3ad918e",
+   "id": "50e03836",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.360585Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.360539Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.362222Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.361977Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.757028Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.756901Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.759355Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.759091Z"
     }
    },
    "outputs": [
@@ -988,11 +1027,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "L 1  -+-+-+-+-+  score=2.0  ambig=2\n",
+      "L 1  -+-+-+-+-+  score=1.0  ambig=1\n",
       "L 2  -+-+-+-+-+  score=1.0  ambig=1\n",
       "L 3  -+-+-+-+-+  score=2.0  ambig=3\n",
       "L 4  -+-+-+-+-+  score=0.0  ambig=1\n",
-      "L 5  -+-+-+-+-+  score=3.0  ambig=8\n",
+      "L 5  -+-+-+-+-+  score=2.0  ambig=4\n",
       "L 6  -+-+-+-+-+  score=0.0  ambig=1\n"
      ]
     }
@@ -1007,7 +1046,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff10a84a",
+   "id": "740caa4f",
    "metadata": {},
    "source": [
     "## The parsed DataFrame\n",
@@ -1018,13 +1057,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "79c7b422",
+   "id": "af586d7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.363096Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.363043Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.371178Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.370935Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.760760Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.760645Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.770230Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.769950Z"
     }
    },
    "outputs": [
@@ -1082,7 +1121,7 @@
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1101,23 +1140,23 @@
        "      <th>1</th>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
+       "      <td>1</td>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
        "      <td>1</td>\n",
        "      <td>s</td>\n",
        "      <td>in</td>\n",
-       "      <td>ɪn</td>\n",
-       "      <td>False</td>\n",
+       "      <td>'ɪn</td>\n",
+       "      <td>True</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
@@ -1130,7 +1169,7 @@
        "      <td>2</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1154,7 +1193,7 @@
        "      <td>3</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1178,7 +1217,7 @@
        "      <td>4</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1202,7 +1241,7 @@
        "      <td>5</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1226,7 +1265,7 @@
        "      <td>6</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1250,7 +1289,7 @@
        "      <td>7</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1274,7 +1313,7 @@
        "      <td>8</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1298,7 +1337,7 @@
        "      <td>9</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>...</td>\n",
@@ -1320,20 +1359,20 @@
       ],
       "text/plain": [
        "   line_num  word_num  form_idx  syll_idx  line_syll_idx  parse_idx  parse_rank  parse_score  is_best  is_bounded  ...  pos_size  meter_val syll_txt syll_ipa is_stressed  *w_peak  *w_stress  \\\n",
-       "0         1         1         0         0              0          1           1          2.0     True       False  ...         1          w     When      wɛn       False        0          0   \n",
-       "1         1         2         0         0              1          1           1          2.0     True       False  ...         1          s       in       ɪn       False        0          0   \n",
-       "2         1         3         0         0              2          1           1          2.0     True       False  ...         1          w      the       ðə       False        0          0   \n",
-       "3         1         4         0         0              3          1           1          2.0     True       False  ...         1          s     chro     'krɑ        True        0          0   \n",
-       "4         1         4         0         1              4          1           1          2.0     True       False  ...         1          w       ni       nɪ       False        0          0   \n",
-       "5         1         4         0         2              5          1           1          2.0     True       False  ...         1          s      cle      kəl       False        0          0   \n",
-       "6         1         5         0         0              6          1           1          2.0     True       False  ...         1          w       of       ʌv       False        0          0   \n",
-       "7         1         6         0         0              7          1           1          2.0     True       False  ...         1          s      was     'weɪ        True        0          0   \n",
-       "8         1         6         0         1              8          1           1          2.0     True       False  ...         1          w      ted     stəd       False        0          0   \n",
-       "9         1         7         0         0              9          1           1          2.0     True       False  ...         1          s     time    'taɪm        True        0          0   \n",
+       "0         1         1         0         0              0          1           1          1.0     True       False  ...         1          w     When      wɛn       False        0          0   \n",
+       "1         1         2         1         0              1          1           1          1.0     True       False  ...         1          s       in      'ɪn        True        0          0   \n",
+       "2         1         3         0         0              2          1           1          1.0     True       False  ...         1          w      the       ðə       False        0          0   \n",
+       "3         1         4         0         0              3          1           1          1.0     True       False  ...         1          s     chro     'krɑ        True        0          0   \n",
+       "4         1         4         0         1              4          1           1          1.0     True       False  ...         1          w       ni       nɪ       False        0          0   \n",
+       "5         1         4         0         2              5          1           1          1.0     True       False  ...         1          s      cle      kəl       False        0          0   \n",
+       "6         1         5         0         0              6          1           1          1.0     True       False  ...         1          w       of       ʌv       False        0          0   \n",
+       "7         1         6         0         0              7          1           1          1.0     True       False  ...         1          s      was     'weɪ        True        0          0   \n",
+       "8         1         6         0         1              8          1           1          1.0     True       False  ...         1          w      ted     stəd       False        0          0   \n",
+       "9         1         7         0         0              9          1           1          1.0     True       False  ...         1          s     time    'taɪm        True        0          0   \n",
        "\n",
        "   *s_unstress  *unres_across  *unres_within  \n",
        "0            0              0              0  \n",
-       "1            1              0              0  \n",
+       "1            0              0              0  \n",
        "2            0              0              0  \n",
        "3            0              0              0  \n",
        "4            0              0              0  \n",
@@ -1358,13 +1397,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a8cb3e3c",
+   "id": "b4cab3f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.372110Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.372070Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.373788Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.373456Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.771504Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.771419Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.773764Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.773465Z"
     }
    },
    "outputs": [
@@ -1406,7 +1445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57cf8022",
+   "id": "1d3698c7",
    "metadata": {},
    "source": [
     "## Custom meters\n",
@@ -1417,13 +1456,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "cbc1d261",
+   "id": "b1c2c7b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.374452Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.374414Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.376038Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.375713Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.775246Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.775132Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.777269Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.776928Z"
     }
    },
    "outputs": [
@@ -1447,13 +1486,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "3152b315",
+   "id": "f78adf67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.376767Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.376702Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.380060Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.379734Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.778535Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.778432Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.836893Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.836596Z"
     }
    },
    "outputs": [
@@ -1473,7 +1512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5b8e23a",
+   "id": "a6174d97",
    "metadata": {},
    "source": [
     "## Poem-level analysis\n",
@@ -1484,13 +1523,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "fb877640",
+   "id": "f23a04e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.380835Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.380792Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.382601Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.382371Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.838341Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.838231Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.841514Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.841242Z"
     }
    },
    "outputs": [
@@ -1500,14 +1539,11 @@
        "{'foot': 'binary',\n",
        " 'head': 'final',\n",
        " 'type': 'iambic',\n",
-       " 'mpos_freqs': {'w': 0.48175182481751827,\n",
-       "  's': 0.48905109489051096,\n",
-       "  'ww': 0.021897810218978103,\n",
-       "  'ss': 0.0072992700729927005},\n",
+       " 'mpos_freqs': {'w': 0.49645390070921985, 's': 0.5035460992907801},\n",
        " 'perc_lines_starting': {'w': 0.9285714285714286, 's': 0.07142857142857142},\n",
-       " 'perc_lines_ending': {'s': 0.8571428571428571, 'w': 0.14285714285714285},\n",
-       " 'perc_lines_fourth': {'s': 0.8571428571428571, 'w': 0.14285714285714285},\n",
-       " 'ambiguity': 2.4793969867312335}"
+       " 'perc_lines_ending': {'s': 1.0},\n",
+       " 'perc_lines_fourth': {'s': 0.9285714285714286, 'w': 0.07142857142857142},\n",
+       " 'ambiguity': 1.0}"
       ]
      },
      "execution_count": 17,
@@ -1523,13 +1559,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "195d6973",
+   "id": "02ffb5c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.383403Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.383353Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.391233Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.390948Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.843231Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.843080Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.854982Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.854706Z"
     }
    },
    "outputs": [
@@ -1537,7 +1573,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "feet  scheme: {'combo': (5,), 'diff': 8}\n",
+      "feet  scheme: {'combo': (5,), 'diff': 2}\n",
       "syll  scheme: {'combo': (10,), 'diff': 1}\n"
      ]
     }
@@ -1550,7 +1586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4638a56b",
+   "id": "b8b03ffa",
    "metadata": {},
    "source": [
     "### Rhyme detection\n",
@@ -1561,13 +1597,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "41ab6a90",
+   "id": "032ef998",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.392052Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.392012Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.393713Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.393365Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.856450Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.856343Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.858934Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.858601Z"
     }
    },
    "outputs": [
@@ -1590,13 +1626,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "f2609d52",
+   "id": "ea2ee362",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.394357Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.394319Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.400048Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.399753Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.860492Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.860369Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.869473Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.869201Z"
     }
    },
    "outputs": [
@@ -1619,13 +1655,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "13efdffd",
+   "id": "e1659d6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.401198Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.401131Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.404782Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.404461Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.870799Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.870710Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.876006Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.875715Z"
     }
    },
    "outputs": [
@@ -1647,7 +1683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49d2db04",
+   "id": "23bfa850",
    "metadata": {},
    "source": [
     "### Named rhyme scheme matching\n",
@@ -1658,13 +1694,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "841bb486",
+   "id": "ddbf3e32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.405527Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.405487Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.407548Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.407293Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.877359Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.877271Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.880282Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.879952Z"
     }
    },
    "outputs": [
@@ -1699,13 +1735,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "680a9937",
+   "id": "58c77f53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.408231Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.408191Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.410861Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.410530Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.881669Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.881571Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.884896Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.884584Z"
     }
    },
    "outputs": [
@@ -1726,7 +1762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cce3680",
+   "id": "7a7b585c",
    "metadata": {},
    "source": [
     "### Tabular summary\n",
@@ -1737,13 +1773,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "2d7cba0f",
+   "id": "d17d1f9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.411577Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.411538Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.420104Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.419748Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.886199Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.886097Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.900876Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.900594Z"
     }
    },
    "outputs": [
@@ -1753,20 +1789,20 @@
      "text": [
       "  #st    #ln  parse        rhyme      #feet    #syll    #parse\n",
       "-----  -----  -----------  -------  -------  -------  --------\n",
-      "    1      1  -+-+-+-+-+   a              5       10         2\n",
+      "    1      1  -+-+-+-+-+   a              5       10         1\n",
       "    1      2  -+-+-+-+-+   b              5       10         1\n",
-      "    1      3  -+-+-+-+-+   a              5       10         3\n",
+      "    1      3  -+-+-+-+-+   a              5       10         1\n",
       "    1      4  -+-+-+-+-+   b              5       10         1\n",
-      "    1      5  -+-+-+-+-+   -              5       10         8\n",
+      "    1      5  -+-+-+-+-+   -              5       10         1\n",
       "    1      6  -+-+-+-+-+   c              5       10         1\n",
-      "    1      7  -+--++-+-+   -              4       10         8\n",
-      "    1      8  +-+-+-+-+-+  c              6       11         2\n",
-      "    1      9  -+-+-+-+--   -              4       10         3\n",
-      "    1     10  -+-+-+-+--   d              4       10         6\n",
-      "    1     11  -+-+-+-+-+   e              5       10         2\n",
-      "    1     12  -+-+-+-+-+   d              5       10         2\n",
-      "    1     13  -+-+-+-+-+   e              5       10         2\n",
-      "    1     14  -+-+-+-+-+   e              5       10         3\n",
+      "    1      7  -+-+-+-+-+   -              5       10         1\n",
+      "    1      8  +-+-+-+-+-+  c              6       11         1\n",
+      "    1      9  -+-+-+-+-+   -              5       10         1\n",
+      "    1     10  -+-+-+-+-+   d              5       10         1\n",
+      "    1     11  -+-+-+-+-+   e              5       10         1\n",
+      "    1     12  -+-+-+-+-+   d              5       10         1\n",
+      "    1     13  -+-+-+-+-+   e              5       10         1\n",
+      "    1     14  -+-+-+-+-+   e              5       10         1\n",
       "\n",
       "\n",
       "estimated schema\n",
@@ -1784,7 +1820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c1c34eb",
+   "id": "b00af675",
    "metadata": {},
    "source": [
     "## MaxEnt weight learning\n",
@@ -1795,13 +1831,13 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "74e90009",
+   "id": "c0484999",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.420917Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.420876Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.446765Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.446518Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.902229Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.902148Z",
+     "iopub.status.idle": "2026-07-04T19:07:04.919783Z",
+     "shell.execute_reply": "2026-07-04T19:07:04.919495Z"
     }
    },
    "outputs": [
@@ -1809,7 +1845,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[93m[0.83s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)\u001b[0m\n"
+      "\u001b[93m[1.44s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)\u001b[0m\n"
      ]
     },
     {
@@ -1817,14 +1853,14 @@
      "output_type": "stream",
      "text": [
       "top learned weights (zone × constraint):\n",
-      "  +6.162  s_unstress_z1\n",
-      "  +4.707  unres_within_z3\n",
-      "  +4.149  unres_across_z2\n",
-      "  +3.641  unres_across_z3\n",
-      "  +3.557  unres_within_z2\n",
-      "  +2.884  s_unstress_z3\n",
-      "  +2.374  unres_across_z1\n",
-      "  +2.075  w_stress_z2\n"
+      "  +5.069  unres_within_z3\n",
+      "  +4.701  unres_across_z3\n",
+      "  +4.281  unres_across_z2\n",
+      "  +4.190  unres_within_z2\n",
+      "  +3.449  s_unstress_z1\n",
+      "  +3.043  w_stress_z3\n",
+      "  +2.840  unres_across_z1\n",
+      "  +1.726  w_stress_z2\n"
      ]
     }
    ],
@@ -1843,7 +1879,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7cf0495",
+   "id": "d8eea88d",
    "metadata": {},
    "source": [
     "## Phrasal stress (optional)\n",
@@ -1859,7 +1895,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dac93a25",
+   "id": "747ad2f7",
    "metadata": {},
    "source": [
     "## Save and load\n",
@@ -1870,13 +1906,13 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "78588fe6",
+   "id": "568c48fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:58:15.447706Z",
-     "iopub.status.busy": "2026-05-04T17:58:15.447664Z",
-     "iopub.status.idle": "2026-05-04T17:58:15.540933Z",
-     "shell.execute_reply": "2026-05-04T17:58:15.540543Z"
+     "iopub.execute_input": "2026-07-04T19:07:04.921172Z",
+     "iopub.status.busy": "2026-07-04T19:07:04.921080Z",
+     "iopub.status.idle": "2026-07-04T19:07:05.003325Z",
+     "shell.execute_reply": "2026-07-04T19:07:05.002922Z"
     }
    },
    "outputs": [
@@ -1884,7 +1920,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "saved files:\n",
+      "saved files:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "  meta.json\n",
       "  parsed.parquet\n",
       "  syll.parquet\n",
@@ -1896,14 +1939,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "reloaded: 14 lines, parse cached?"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " True\n"
+      "reloaded: 14 lines, parse cached? True\n"
      ]
     }
    ],
@@ -1924,7 +1960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4af75dd7",
+   "id": "55e3c351",
    "metadata": {},
    "source": [
     "## Web app\n",
@@ -1937,12 +1973,12 @@
     "prosodic web --dev               # auto-reload backend + frontend\n",
     "```\n",
     "\n",
-    "Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. See `prosodic/web/` for the implementation."
+    "Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. Results are **shareable via permalink**, exportable as CSV/TSV/JSON, and long/prose lines fall back to phrase-level parsing automatically. See `prosodic/web/` for the implementation."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b56ffbde",
+   "id": "c1f78ce2",
    "metadata": {},
    "source": [
     "## Remote client\n",
@@ -1964,7 +2000,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "656ce79c",
+   "id": "76167cf6",
    "metadata": {},
    "source": [
     "## Further reading\n",
@@ -1988,7 +2024,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -24,36 +24,9 @@ You'll also need [espeak](https://github.com/espeak-ng/espeak-ng) (free TTS) to 
 - **Linux**: `apt-get install espeak libespeak1 libespeak-dev`
 - **Windows**: download from the [espeak-ng releases](https://github.com/espeak-ng/espeak-ng/releases/latest)
 
-### Setup (Colab only)
-
-Skip this cell when running locally. It installs system + Python deps in a Colab runtime.
-
-
-```python
-# Auto-install dependencies if running in Google Colab.
-# Locally this is a no-op.
-import sys
-IN_COLAB = "google.colab" in sys.modules
-if IN_COLAB:
-    import subprocess
-    subprocess.run(
-        ["apt-get", "-qq", "install", "-y",
-         "espeak", "libespeak1", "libespeak-dev"],
-        check=True,
-    )
-    subprocess.run(["pip", "install", "-q", "prosodic"], check=True)
-    print("Colab setup complete.")
-else:
-    print("Local environment — skipping Colab setup.")
-```
-
-    Local environment — skipping Colab setup.
-
-
 ## Quickstart
 
 A complete tour of Prosodic in five lines.
-
 
 ```python
 import prosodic
@@ -79,18 +52,18 @@ print(sonnet.summary())
 
       #st    #ln  parse        rhyme      #feet    #syll    #parse
     -----  -----  -----------  -------  -------  -------  --------
-        1      1  -+-+-+-+-+   a              5       10         2
+        1      1  -+-+-+-+-+   a              5       10         1
         1      2  -+-+-+-+-+   b              5       10         1
         1      3  -+-+-+-+-+   a              5       10         3
         1      4  -+-+-+-+-+   b              5       10         1
-        1      5  -+-+-+-+-+   -              5       10         8
+        1      5  -+-+-+-+-+   -              5       10         4
         1      6  -+-+-+-+-+   c              5       10         1
-        1      7  -+--++-+-+   -              4       10         8
+        1      7  -+--++-+-+   -              4       10         6
         1      8  +-+-+-+-+-+  c              6       11         2
         1      9  -+-+-+-+--   -              4       10         3
         1     10  -+-+-+-+--   d              4       10         6
         1     11  -+-+-+-+-+   e              5       10         2
-        1     12  -+-+-+-+-+   d              5       10         2
+        1     12  -+-+-+-+-+   d              5       10         1
         1     13  -+-+-+-+-+   e              5       10         2
         1     14  -+-+-+-+-+   e              5       10         3
     
@@ -102,11 +75,9 @@ print(sonnet.summary())
     syllables: 10
     rhyme: Sonnet A (abab cdcd eefeff)
 
-
 ## Reading texts
 
 You can build a `Text` from a string, a file, or just a single line.
-
 
 ```python
 # from a string
@@ -125,31 +96,36 @@ print(f"single line: {line}")
 
     short: 1 line(s)
 
+    [32m[1.79s] Building long text[0m:   0%|          | 0/20307 [00:00<?, ?it/s]
 
-    [32m[1.93s] Building long text[0m:   0%|          | 0/20307 [00:00<?, ?it/s]
+    [32m[1.79s] Building long text[0m:   8%|▊         | 1634/20307 [00:00<00:01, 9792.06it/s]
 
-    [32m[1.93s] Building long text[0m:  16%|█▌        | 3167/20307 [00:00<00:00, 24475.44it/s]
+    [32m[1.79s] Building long text[0m:  19%|█▉        | 3853/20307 [00:00<00:01, 15508.92it/s]
 
-    [32m[1.93s] Building long text[0m:  35%|███▍      | 7015/20307 [00:00<00:00, 31822.63it/s]
+    [32m[1.79s] Building long text[0m:  30%|███       | 6103/20307 [00:00<00:00, 18285.35it/s]
 
-    [32m[1.93s] Building long text[0m:  51%|█████     | 10287/20307 [00:00<00:00, 28739.40it/s]
+    [32m[1.79s] Building long text[0m:  40%|███▉      | 8059/20307 [00:00<00:00, 14569.55it/s]
 
-    [32m[1.93s] Building long text[0m:  70%|██████▉   | 14152/20307 [00:00<00:00, 32236.26it/s]
+    [32m[1.79s] Building long text[0m:  51%|█████     | 10304/20307 [00:00<00:00, 16827.48it/s]
 
-    [32m[1.93s] Building long text[0m:  86%|████████▌ | 17459/20307 [00:00<00:00, 28657.85it/s]
+    [32m[1.79s] Building long text[0m:  62%|██████▏   | 12536/20307 [00:00<00:00, 18421.13it/s]
+
+    [32m[1.79s] Building long text[0m:  71%|███████▏  | 14511/20307 [00:00<00:00, 14750.34it/s]
+
+    [32m[1.79s] Building long text[0m:  82%|████████▏ | 16753/20307 [00:01<00:00, 16646.55it/s]
+
+    [32m[1.79s] Building long text[0m:  94%|█████████▍| 19082/20307 [00:01<00:00, 18379.62it/s]
 
                                                                                         
 
     sonnets: 2,155 lines, 154 stanzas
     single line: Line(num=1, txt="Shall I compare thee to a summer's day?")
 
-
     
 
 ## The hierarchy: stanzas → lines → words → syllables → phonemes
 
 Prosodic organizes text into a tree of linguistic entities. Children are constructed lazily on first access — the underlying source of truth is a per-syllable DataFrame.
-
 
 ```python
 # tree access
@@ -162,189 +138,27 @@ print(f"first word: {sonnet.lines[0].wordtokens[0]}")
     line 1 has 7 word tokens
     first word: WordToken(num=1, txt='When', lang='en', para_num=1, line_num=1, sent_num=1, sentpart_num=1, linepart_num=1)
 
-
-
 ```python
 # attribute shortcut: text.line1 == text.lines[0]
 sonnet.line1
 ```
 
+**Line**
 
-
-
-<b>Line</b><br><div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th></th>
-      <th>wordtoken_is_punc</th>
-    </tr>
-    <tr>
-      <th>stanza_num</th>
-      <th>line_num</th>
-      <th>linepart_num</th>
-      <th>sent_num</th>
-      <th>sentpart_num</th>
-      <th>wordtoken_num</th>
-      <th>wordtoken_txt</th>
-      <th>wordtype_txt</th>
-      <th>wordform_num</th>
-      <th>wordform_ipa_origin</th>
-      <th>syll_num</th>
-      <th>syll_txt</th>
-      <th>syll_ipa</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th rowspan="11" valign="top">1</th>
-      <th rowspan="11" valign="top">1</th>
-      <th rowspan="11" valign="top">1</th>
-      <th rowspan="11" valign="top">1</th>
-      <th rowspan="11" valign="top">1</th>
-      <th rowspan="2" valign="top">1</th>
-      <th rowspan="2" valign="top">When</th>
-      <th rowspan="2" valign="top">When</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>When</th>
-      <th>wɛn</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>When</th>
-      <th>'wɛn</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th rowspan="2" valign="top">2</th>
-      <th rowspan="2" valign="top">in</th>
-      <th rowspan="2" valign="top">in</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>in</th>
-      <th>ɪn</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>in</th>
-      <th>'ɪn</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <th>the</th>
-      <th>the</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>the</th>
-      <th>ðə</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <th>...</th>
-      <td>...</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <th>chronicle</th>
-      <th>chronicle</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>3</th>
-      <th>cle</th>
-      <th>kəl</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>5</th>
-      <th>of</th>
-      <th>of</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>of</th>
-      <th>ʌv</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th rowspan="2" valign="top">6</th>
-      <th rowspan="2" valign="top">wasted</th>
-      <th rowspan="2" valign="top">wasted</th>
-      <th rowspan="2" valign="top">1</th>
-      <th rowspan="2" valign="top">dict</th>
-      <th>1</th>
-      <th>was</th>
-      <th>'weɪ</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <th>ted</th>
-      <th>stəd</th>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>7</th>
-      <th>time</th>
-      <th>time</th>
-      <th>1</th>
-      <th>dict</th>
-      <th>1</th>
-      <th>time</th>
-      <th>'taɪm</th>
-      <td>0</td>
-    </tr>
-  </tbody>
-</table>
-<p>12 rows × 1 columns</p>
-</div>
-
-
-
-
+|   stanza_num |   line_num |   linepart_num |   sent_num |   sentpart_num | wordtoken_num   | wordtoken_txt   | wordtype_txt   | wordform_num   | wordform_ipa_origin   | syll_num   | syll_txt   | syll_ipa   | wordtoken_is_punc   |
+|-------------:|-----------:|---------------:|-----------:|---------------:|:----------------|:----------------|:---------------|:---------------|:----------------------|:-----------|:-----------|:-----------|:--------------------|
+|            1 |          1 |              1 |          1 |              1 | 1               | When            | When           | 1              | dict                  | 1          | When       | wɛn        | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 1               | When            | When           | 2              | dict                  | 1          | When       | 'wɛn       | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 2               | in              | in             | 1              | dict                  | 1          | in         | ɪn         | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 2               | in              | in             | 2              | dict                  | 1          | in         | 'ɪn        | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 3               | the             | the            | 1              | dict                  | 1          | the        | ðə         | 0                   |
+|            1 |          1 |              1 |          1 |              1 | ...             | ...             | ...            | ...            | ...                   | ...        | ...        | ...        | ...                 |
+|            1 |          1 |              1 |          1 |              1 | 4               | chronicle       | chronicle      | 1              | dict                  | 3          | cle        | kəl        | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 5               | of              | of             | 1              | dict                  | 1          | of         | ʌv         | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 1          | was        | 'weɪ       | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 2          | ted        | stəd       | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 7               | time            | time           | 1              | dict                  | 1          | time       | 'taɪm      | 0                   |
+*12 rows × 1 columns*
 ```python
 # wordform → syllable → phoneme
 wordform = sonnet.line1.wordtokens[1].wordform
@@ -360,241 +174,29 @@ for syll in wordform.syllables:
         phon: 'ɪ'
         phon: 'n'
 
-
 ## DataFrame view
 
 The whole text is also accessible as a flat per-syllable DataFrame. This is the source of truth — entities are constructed from it on demand.
-
 
 ```python
 # .df is the syllable-level DataFrame
 sonnet.df.head(8)
 ```
 
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>word_num</th>
-      <th>line_num</th>
-      <th>para_num</th>
-      <th>sent_num</th>
-      <th>sentpart_num</th>
-      <th>linepart_num</th>
-      <th>word_txt</th>
-      <th>is_punc</th>
-      <th>form_idx</th>
-      <th>num_forms</th>
-      <th>syll_idx</th>
-      <th>syll_ipa</th>
-      <th>syll_text</th>
-      <th>is_stressed</th>
-      <th>is_heavy</th>
-      <th>is_strong</th>
-      <th>is_weak</th>
-      <th>is_functionword</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>When</td>
-      <td>0</td>
-      <td>0</td>
-      <td>2</td>
-      <td>0</td>
-      <td>wɛn</td>
-      <td>When</td>
-      <td>False</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-      <td>True</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>When</td>
-      <td>0</td>
-      <td>1</td>
-      <td>2</td>
-      <td>0</td>
-      <td>'wɛn</td>
-      <td>When</td>
-      <td>True</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>2</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>in</td>
-      <td>0</td>
-      <td>0</td>
-      <td>2</td>
-      <td>0</td>
-      <td>ɪn</td>
-      <td>in</td>
-      <td>False</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-      <td>True</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>2</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>in</td>
-      <td>0</td>
-      <td>1</td>
-      <td>2</td>
-      <td>0</td>
-      <td>'ɪn</td>
-      <td>in</td>
-      <td>True</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>3</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>the</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>ðə</td>
-      <td>the</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-      <td>True</td>
-    </tr>
-    <tr>
-      <th>5</th>
-      <td>4</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>chronicle</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>'krɑ</td>
-      <td>chro</td>
-      <td>True</td>
-      <td>False</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-    </tr>
-    <tr>
-      <th>6</th>
-      <td>4</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>chronicle</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>1</td>
-      <td>nɪ</td>
-      <td>ni</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-      <td>True</td>
-      <td>False</td>
-    </tr>
-    <tr>
-      <th>7</th>
-      <td>4</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>chronicle</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>2</td>
-      <td>kəl</td>
-      <td>cle</td>
-      <td>False</td>
-      <td>True</td>
-      <td>False</td>
-      <td>False</td>
-      <td>False</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-
-
-
-
+|    |   word_num |   line_num |   para_num |   sent_num |   sentpart_num |   linepart_num | word_txt   |   is_punc |   form_idx |   num_forms |   syll_idx | syll_ipa   | syll_text   | is_stressed   | is_heavy   | is_strong   | is_weak   | is_functionword   |
+|---:|-----------:|-----------:|-----------:|-----------:|---------------:|---------------:|:-----------|----------:|-----------:|------------:|-----------:|:-----------|:------------|:--------------|:-----------|:------------|:----------|:------------------|
+|  0 |          1 |          1 |          1 |          1 |              1 |              1 | When       |         0 |          0 |           2 |          0 | wɛn        | When        | False         | True       | False       | False     | True              |
+|  1 |          1 |          1 |          1 |          1 |              1 |              1 | When       |         0 |          1 |           2 |          0 | 'wɛn       | When        | True          | True       | False       | False     | False             |
+|  2 |          2 |          1 |          1 |          1 |              1 |              1 | in         |         0 |          0 |           2 |          0 | ɪn         | in          | False         | True       | False       | False     | True              |
+|  3 |          2 |          1 |          1 |          1 |              1 |              1 | in         |         0 |          1 |           2 |          0 | 'ɪn        | in          | True          | True       | False       | False     | False             |
+|  4 |          3 |          1 |          1 |          1 |              1 |              1 | the        |         0 |          0 |           1 |          0 | ðə         | the         | False         | False      | False       | False     | True              |
+|  5 |          4 |          1 |          1 |          1 |              1 |              1 | chronicle  |         0 |          0 |           1 |          0 | 'krɑ       | chro        | True          | False      | True        | False     | False             |
+|  6 |          4 |          1 |          1 |          1 |              1 |              1 | chronicle  |         0 |          0 |           1 |          1 | nɪ         | ni          | False         | False      | False       | True      | False             |
+|  7 |          4 |          1 |          1 |          1 |              1 |              1 | chronicle  |         0 |          0 |           1 |          2 | kəl        | cle         | False         | True       | False       | False     | False             |
 ```python
 # columns
 list(sonnet.df.columns)
 ```
-
-
-
 
     ['word_num',
      'line_num',
@@ -615,12 +217,9 @@ list(sonnet.df.columns)
      'is_weak',
      'is_functionword']
 
-
-
 ## Metrical parsing
 
 `text.parse()` runs an exhaustive vectorized parser: it evaluates every possible scansion against a configurable set of metrical constraints (numpy on CPU, torch on GPU when available), then uses harmonic bounding to identify optimal parses. Constraints include `w_peak` (no peak in weak position), `w_stress` (no stress in weak), `s_unstress` (no unstress in strong), `unres_within`/`unres_across` (no unresolved disyllables), `foot_size`. See `prosodic/parsing/constraints.py` for the full list.
-
 
 ```python
 # parse a single line
@@ -630,8 +229,6 @@ print(line.best_parse)
 ```
 
     Parse(txt="shall I com PARE thee TO a SUM mer's DAY")
-
-
 
 ```python
 # inspect the parse
@@ -651,8 +248,6 @@ print(f"is_rising: {bp.is_rising}")
     foot_type: iambic    (per-parse classification)
     is_rising: True
 
-
-
 ```python
 # all unbounded parses for the line, sorted by score
 for p in line.parses.unbounded:
@@ -660,8 +255,6 @@ for p in line.parses.unbounded:
 ```
 
     -+-+-+-+-+  score=2.0
-
-
 
 ```python
 # parse the full sonnet
@@ -671,323 +264,38 @@ for line in sonnet.lines[:6]:
     print(f"L{line.num:2d}  {bp.meter_str}  score={bp.score:.1f}  ambig={len(line.parses.unbounded)}")
 ```
 
-    L 1  -+-+-+-+-+  score=2.0  ambig=2
+    L 1  -+-+-+-+-+  score=1.0  ambig=1
     L 2  -+-+-+-+-+  score=1.0  ambig=1
     L 3  -+-+-+-+-+  score=2.0  ambig=3
     L 4  -+-+-+-+-+  score=0.0  ambig=1
-    L 5  -+-+-+-+-+  score=3.0  ambig=8
+    L 5  -+-+-+-+-+  score=2.0  ambig=4
     L 6  -+-+-+-+-+  score=0.0  ambig=1
-
 
 ## The parsed DataFrame
 
 Per-syllable parse results across the whole text — useful for analysis, plotting, or export.
 
-
 ```python
 sonnet.parsed_df.head(10)
 ```
 
-
-
-
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
-<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th></th>
-      <th>line_num</th>
-      <th>word_num</th>
-      <th>form_idx</th>
-      <th>syll_idx</th>
-      <th>line_syll_idx</th>
-      <th>parse_idx</th>
-      <th>parse_rank</th>
-      <th>parse_score</th>
-      <th>is_best</th>
-      <th>is_bounded</th>
-      <th>...</th>
-      <th>pos_size</th>
-      <th>meter_val</th>
-      <th>syll_txt</th>
-      <th>syll_ipa</th>
-      <th>is_stressed</th>
-      <th>*w_peak</th>
-      <th>*w_stress</th>
-      <th>*s_unstress</th>
-      <th>*unres_across</th>
-      <th>*unres_within</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>1</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>w</td>
-      <td>When</td>
-      <td>wɛn</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>1</td>
-      <td>2</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>s</td>
-      <td>in</td>
-      <td>ɪn</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>2</th>
-      <td>1</td>
-      <td>3</td>
-      <td>0</td>
-      <td>0</td>
-      <td>2</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>w</td>
-      <td>the</td>
-      <td>ðə</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>3</th>
-      <td>1</td>
-      <td>4</td>
-      <td>0</td>
-      <td>0</td>
-      <td>3</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>s</td>
-      <td>chro</td>
-      <td>'krɑ</td>
-      <td>True</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>4</th>
-      <td>1</td>
-      <td>4</td>
-      <td>0</td>
-      <td>1</td>
-      <td>4</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>w</td>
-      <td>ni</td>
-      <td>nɪ</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>5</th>
-      <td>1</td>
-      <td>4</td>
-      <td>0</td>
-      <td>2</td>
-      <td>5</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>s</td>
-      <td>cle</td>
-      <td>kəl</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>1</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>6</th>
-      <td>1</td>
-      <td>5</td>
-      <td>0</td>
-      <td>0</td>
-      <td>6</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>w</td>
-      <td>of</td>
-      <td>ʌv</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>7</th>
-      <td>1</td>
-      <td>6</td>
-      <td>0</td>
-      <td>0</td>
-      <td>7</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>s</td>
-      <td>was</td>
-      <td>'weɪ</td>
-      <td>True</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>8</th>
-      <td>1</td>
-      <td>6</td>
-      <td>0</td>
-      <td>1</td>
-      <td>8</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>w</td>
-      <td>ted</td>
-      <td>stəd</td>
-      <td>False</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-    <tr>
-      <th>9</th>
-      <td>1</td>
-      <td>7</td>
-      <td>0</td>
-      <td>0</td>
-      <td>9</td>
-      <td>1</td>
-      <td>1</td>
-      <td>2.0</td>
-      <td>True</td>
-      <td>False</td>
-      <td>...</td>
-      <td>1</td>
-      <td>s</td>
-      <td>time</td>
-      <td>'taɪm</td>
-      <td>True</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-      <td>0</td>
-    </tr>
-  </tbody>
-</table>
-<p>10 rows × 21 columns</p>
-</div>
-
-
-
-
+|    |   line_num |   word_num |   form_idx |   syll_idx |   line_syll_idx |   parse_idx |   parse_rank |   parse_score | is_best   | is_bounded   | ...   |   pos_size | meter_val   | syll_txt   | syll_ipa   | is_stressed   |   *w_peak |   *w_stress |   *s_unstress |   *unres_across |   *unres_within |
+|---:|-----------:|-----------:|-----------:|-----------:|----------------:|------------:|-------------:|--------------:|:----------|:-------------|:------|-----------:|:------------|:-----------|:-----------|:--------------|----------:|------------:|--------------:|----------------:|----------------:|
+|  0 |          1 |          1 |          0 |          0 |               0 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | When       | wɛn        | False         |         0 |           0 |             0 |               0 |               0 |
+|  1 |          1 |          2 |          1 |          0 |               1 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | in         | 'ɪn        | True          |         0 |           0 |             0 |               0 |               0 |
+|  2 |          1 |          3 |          0 |          0 |               2 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | the        | ðə         | False         |         0 |           0 |             0 |               0 |               0 |
+|  3 |          1 |          4 |          0 |          0 |               3 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | chro       | 'krɑ       | True          |         0 |           0 |             0 |               0 |               0 |
+|  4 |          1 |          4 |          0 |          1 |               4 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | ni         | nɪ         | False         |         0 |           0 |             0 |               0 |               0 |
+|  5 |          1 |          4 |          0 |          2 |               5 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | cle        | kəl        | False         |         0 |           0 |             1 |               0 |               0 |
+|  6 |          1 |          5 |          0 |          0 |               6 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | of         | ʌv         | False         |         0 |           0 |             0 |               0 |               0 |
+|  7 |          1 |          6 |          0 |          0 |               7 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | was        | 'weɪ       | True          |         0 |           0 |             0 |               0 |               0 |
+|  8 |          1 |          6 |          0 |          1 |               8 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | ted        | stəd       | False         |         0 |           0 |             0 |               0 |               0 |
+|  9 |          1 |          7 |          0 |          0 |               9 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | time       | 'taɪm      | True          |         0 |           0 |             0 |               0 |               0 |
+*10 rows × 21 columns*
 ```python
 # every column you might want for analysis
 list(sonnet.parsed_df.columns)
 ```
-
-
-
 
     ['line_num',
      'word_num',
@@ -1011,12 +319,9 @@ list(sonnet.parsed_df.columns)
      '*unres_across',
      '*unres_within']
 
-
-
 ## Custom meters
 
 The default `Meter` allows up to 2-syllable strong/weak positions. You can change constraints, weights, position widths, or unit of parsing.
-
 
 ```python
 # stricter binary meter
@@ -1029,8 +334,6 @@ print(strict)
 
     Meter(constraints={'w_peak': 1.0, 'w_stress': 1.0, 's_unstress': 1.0, 'foot_size': 1.0}, max_s=1, max_w=1, resolve_optionality=True, parse_unit='line')
 
-
-
 ```python
 # parse with a custom meter
 sonnet.parse(meter=strict)
@@ -1039,34 +342,23 @@ print(sonnet.line1.best_parse)
 
     Parse(txt='when IN the CHRO ni CLE of WAS ted TIME')
 
-
 ## Poem-level analysis
 
 Prosodic 3 includes `prosodic/analysis/` (a port of the standalone [poesy](https://github.com/quadrismegistus/poesy) package) for higher-order summary statistics over a parsed text.
-
 
 ```python
 # meter classification (iambic / trochaic / anapestic / dactylic)
 sonnet.meter_type
 ```
 
-
-
-
     {'foot': 'binary',
      'head': 'final',
      'type': 'iambic',
-     'mpos_freqs': {'w': 0.48175182481751827,
-      's': 0.48905109489051096,
-      'ww': 0.021897810218978103,
-      'ss': 0.0072992700729927005},
+     'mpos_freqs': {'w': 0.49645390070921985, 's': 0.5035460992907801},
      'perc_lines_starting': {'w': 0.9285714285714286, 's': 0.07142857142857142},
-     'perc_lines_ending': {'s': 0.8571428571428571, 'w': 0.14285714285714285},
-     'perc_lines_fourth': {'s': 0.8571428571428571, 'w': 0.14285714285714285},
-     'ambiguity': 2.4793969867312335}
-
-
-
+     'perc_lines_ending': {'s': 1.0},
+     'perc_lines_fourth': {'s': 0.9285714285714286, 'w': 0.07142857142857142},
+     'ambiguity': 1.0}
 
 ```python
 # repeating beat-length template (e.g. invariable pentameter, ballad meter)
@@ -1074,27 +366,19 @@ print('feet  scheme:', sonnet.line_scheme)
 print('syll  scheme:', sonnet.syllable_scheme)
 ```
 
-    feet  scheme: {'combo': (5,), 'diff': 8}
+    feet  scheme: {'combo': (5,), 'diff': 2}
     syll  scheme: {'combo': (10,), 'diff': 1}
-
 
 ### Rhyme detection
 
 Rhyme is computed via feature-weighted edit distance over IPA segments (panphon). 0 = perfect rhyme; higher = slant rhyme.
-
 
 ```python
 # pairwise rime distance
 sonnet.line1.rime_distance(sonnet.lines[2])  # 'time' vs 'rhyme'
 ```
 
-
-
-
     0.0
-
-
-
 
 ```python
 # every rhyming line in the text, with its closest partner
@@ -1106,8 +390,6 @@ for line, (dist, partner) in list(sonnet.get_rhyming_lines().items())[:6]:
     L 8 ↔ L 6  dist=0.00  'Even such a beauty as you master no' / 'Of hand, of foot, of lip, of eye, o'
     L14 ↔ L13  dist=0.00  'Had eyes to wonder, but lack tongue' / 'For we, which now behold these pres'
 
-
-
 ```python
 # per-line rhyme group IDs (0 = no rhyme partner)
 print('IDs:    ', sonnet.rhyme_ids)
@@ -1118,11 +400,9 @@ print('letters:', ''.join(nums_to_scheme(sonnet.rhyme_ids)))
     IDs:     [1, 2, 1, 2, 0, 3, 0, 3, 0, 4, 5, 4, 5, 5]
     letters: abab-c-c-dedee
 
-
 ### Named rhyme scheme matching
 
 Match observed rhyme groups against a 39-form catalog (Sonnet variants, Couplet, Sestet, Triplet, Rhyme Royal, Spenserian, etc.) by Jaccard similarity over rhyme-edge sets.
-
 
 ```python
 rs = sonnet.rhyme_scheme
@@ -1146,8 +426,6 @@ for name, form, score in rs['candidates'][:5]:
       0.40  Sonnet B                       abab cdcd effegg
       0.36  Sonnet D                       ababbcdc ceceff
 
-
-
 ```python
 # form predicates
 print('is_sonnet:               ', sonnet.is_sonnet)
@@ -1157,11 +435,9 @@ print('is_shakespearean_sonnet: ', sonnet.is_shakespearean_sonnet)
     is_sonnet:                True
     is_shakespearean_sonnet:  False
 
-
 ### Tabular summary
 
 `text.summary()` rolls everything together: per-line parse + rhyme letter + foot/syllable count + ambiguity, plus an estimated-schema block.
-
 
 ```python
 print(sonnet.summary())
@@ -1169,20 +445,20 @@ print(sonnet.summary())
 
       #st    #ln  parse        rhyme      #feet    #syll    #parse
     -----  -----  -----------  -------  -------  -------  --------
-        1      1  -+-+-+-+-+   a              5       10         2
+        1      1  -+-+-+-+-+   a              5       10         1
         1      2  -+-+-+-+-+   b              5       10         1
-        1      3  -+-+-+-+-+   a              5       10         3
+        1      3  -+-+-+-+-+   a              5       10         1
         1      4  -+-+-+-+-+   b              5       10         1
-        1      5  -+-+-+-+-+   -              5       10         8
+        1      5  -+-+-+-+-+   -              5       10         1
         1      6  -+-+-+-+-+   c              5       10         1
-        1      7  -+--++-+-+   -              4       10         8
-        1      8  +-+-+-+-+-+  c              6       11         2
-        1      9  -+-+-+-+--   -              4       10         3
-        1     10  -+-+-+-+--   d              4       10         6
-        1     11  -+-+-+-+-+   e              5       10         2
-        1     12  -+-+-+-+-+   d              5       10         2
-        1     13  -+-+-+-+-+   e              5       10         2
-        1     14  -+-+-+-+-+   e              5       10         3
+        1      7  -+-+-+-+-+   -              5       10         1
+        1      8  +-+-+-+-+-+  c              6       11         1
+        1      9  -+-+-+-+-+   -              5       10         1
+        1     10  -+-+-+-+-+   d              5       10         1
+        1     11  -+-+-+-+-+   e              5       10         1
+        1     12  -+-+-+-+-+   d              5       10         1
+        1     13  -+-+-+-+-+   e              5       10         1
+        1     14  -+-+-+-+-+   e              5       10         1
     
     
     estimated schema
@@ -1192,11 +468,9 @@ print(sonnet.summary())
     syllables: 10
     rhyme: Sonnet A (abab cdcd eefeff)
 
-
 ## MaxEnt weight learning
 
 `Meter.fit()` learns constraint weights from a target scansion (or annotated data) using L-BFGS-B Maximum Entropy optimization (Goldwater & Johnson 2003 / Hayes MaxEnt OT). The learned weights can be split by syllable position (`zones`) so positional sensitivity transfers to parsing.
-
 
 ```python
 # Train weights to match an iambic pentameter target across all sonnet lines
@@ -1211,19 +485,17 @@ for name, w in sorted(meter.zone_weights.items(), key=lambda x: -abs(x[1]))[:8]:
     print(f"  {w:+.3f}  {name}")
 ```
 
-    [93m[0.83s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)[0m
-
+    [93m[1.44s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)[0m
 
     top learned weights (zone × constraint):
-      +6.162  s_unstress_z1
-      +4.707  unres_within_z3
-      +4.149  unres_across_z2
-      +3.641  unres_across_z3
-      +3.557  unres_within_z2
-      +2.884  s_unstress_z3
-      +2.374  unres_across_z1
-      +2.075  w_stress_z2
-
+      +5.069  unres_within_z3
+      +4.701  unres_across_z3
+      +4.281  unres_across_z2
+      +4.190  unres_within_z2
+      +3.449  s_unstress_z1
+      +3.043  w_stress_z3
+      +2.840  unres_across_z1
+      +1.726  w_stress_z2
 
 ## Phrasal stress (optional)
 
@@ -1238,7 +510,6 @@ t.parse()
 ## Save and load
 
 Parquet-backed save/load preserves the syllable DataFrame and any computed parse results — no need to re-parse on reload.
-
 
 ```python
 import tempfile, os, shutil
@@ -1256,17 +527,15 @@ shutil.rmtree(out)
 ```
 
     saved files:
+
+    
       meta.json
       parsed.parquet
       syll.parquet
       text.txt.gz
 
-
     
-    reloaded: 14 lines, parse cached?
-
-     True
-
+    reloaded: 14 lines, parse cached? True
 
 ## Web app
 
@@ -1278,7 +547,7 @@ prosodic web --port 5111
 prosodic web --dev               # auto-reload backend + frontend
 ```
 
-Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. See `prosodic/web/` for the implementation.
+Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. Results are **shareable via permalink**, exportable as CSV/TSV/JSON, and long/prose lines fall back to phrase-level parsing automatically. See `prosodic/web/` for the implementation.
 
 ## Remote client
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ pytest-cov
 pytest>=7.2
 nbformat
 nbclient
+nbconvert
 quarto
 quartodoc
 playwright

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -22,11 +22,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 nb = nbformat.v4.new_notebook()
 cells = []
 
-def md(text):
-    cells.append(nbformat.v4.new_markdown_cell(text))
+def md(text, tags=None):
+    cell = nbformat.v4.new_markdown_cell(text)
+    if tags:
+        cell.metadata["tags"] = tags
+    cells.append(cell)
 
-def code(src):
-    cells.append(nbformat.v4.new_code_cell(src))
+def code(src, tags=None):
+    cell = nbformat.v4.new_code_cell(src)
+    if tags:
+        cell.metadata["tags"] = tags
+    cells.append(cell)
 
 
 md("""# Prosodic 3
@@ -57,7 +63,8 @@ You'll also need [espeak](https://github.com/espeak-ng/espeak-ng) (free TTS) to 
 
 md("""### Setup (Colab only)
 
-Skip this cell when running locally. It installs system + Python deps in a Colab runtime.""")
+Skip this cell when running locally. It installs system + Python deps in a Colab runtime.""",
+   tags=["remove_cell"])
 
 code("""# Auto-install dependencies if running in Google Colab.
 # Locally this is a no-op.
@@ -73,7 +80,8 @@ if IN_COLAB:
     subprocess.run(["pip", "install", "-q", "prosodic"], check=True)
     print("Colab setup complete.")
 else:
-    print("Local environment — skipping Colab setup.")""")
+    print("Local environment — skipping Colab setup.")""",
+     tags=["remove_cell"])
 
 md("""## Quickstart
 
@@ -300,7 +308,7 @@ prosodic web --port 5111
 prosodic web --dev               # auto-reload backend + frontend
 ```
 
-Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. See `prosodic/web/` for the implementation.""")
+Five tabs: **Parse** (text input + corpus dropdown + sortable, paginated results), **Line** (single-line scansion detail showing all candidates), **Meter** (constraint config + weights), **MaxEnt** (annotated-data training), **Settings**. Results are **shareable via permalink**, exportable as CSV/TSV/JSON, and long/prose lines fall back to phrase-level parsing automatically. See `prosodic/web/` for the implementation.""")
 
 md("""## Remote client
 
@@ -332,9 +340,67 @@ nb["cells"] = cells
 client = NotebookClient(nb, timeout=300, kernel_name="python3")
 client.execute(cwd=str(REPO_ROOT))
 
-# Save
+# Save notebook (canonical, Colab-runnable)
 out_path = REPO_ROOT / "README.ipynb"
 with out_path.open("w") as f:
     nbformat.write(nb, f)
+print(f"Wrote {out_path} with {len(cells)} cells.")
 
-print(f"\nWrote {out_path} with {len(cells)} cells.")
+
+def write_readme_md(nb):
+    """Convert the executed notebook to a clean README.md.
+
+    nbconvert alone leaves junk in the markdown: the Colab-only bootstrap cell,
+    pandas DataFrame ``<style scoped>`` CSS blocks (which GitHub strips anyway),
+    and raw ``<table>`` HTML. We drop the tagged Colab cells, strip the CSS, and
+    round-trip the DataFrame tables back through pandas into GitHub-native
+    markdown tables.
+    """
+    import io
+    import re
+    import pandas as pd
+    from nbconvert import MarkdownExporter
+    from traitlets.config import Config
+
+    cfg = Config()
+    cfg.TagRemovePreprocessor.remove_cell_tags = ("remove_cell",)
+    cfg.TagRemovePreprocessor.enabled = True
+    cfg.MarkdownExporter.preprocessors = [
+        "nbconvert.preprocessors.TagRemovePreprocessor"
+    ]
+    body, _ = MarkdownExporter(config=cfg).from_notebook_node(nb)
+
+    # pandas DataFrame CSS is dead weight (GitHub ignores <style>)
+    body = re.sub(r"<style.*?</style>", "", body, flags=re.DOTALL)
+
+    # entity _repr_html_ labels ("<b>Line</b><br>...") -> a bold markdown line
+    body = re.sub(r"<b>(.*?)</b>\s*<br\s*/?>", r"**\1**\n\n", body, flags=re.DOTALL)
+
+    def _clean_col(c):
+        # flatten MultiIndex headers and drop pandas' "Unnamed: N_level" filler
+        if isinstance(c, tuple):
+            parts = [str(x) for x in c if not str(x).startswith("Unnamed")]
+            return " ".join(parts).strip()
+        return "" if str(c).startswith("Unnamed") else str(c)
+
+    # DataFrame HTML tables -> markdown tables
+    def _table_to_md(match):
+        try:
+            df = pd.read_html(io.StringIO(match.group(0)))[0]
+            df.columns = [_clean_col(c) for c in df.columns]
+            return df.to_markdown(index=False)
+        except Exception:
+            return match.group(0)
+
+    body = re.sub(r"<table.*?</table>", _table_to_md, body, flags=re.DOTALL)
+    body = re.sub(r"</?div>\s*", "", body)      # unwrap leftover df <div>s
+    body = re.sub(r"<p>(.*?)</p>", r"*\1*", body, flags=re.DOTALL)  # "N rows × M cols" footer
+    body = re.sub(r"\n{3,}", "\n\n", body)      # collapse blank-line runs
+    body = body.rstrip() + "\n"
+
+    md_path = REPO_ROOT / "README.md"
+    md_path.write_text(body)
+    print(f"Wrote {md_path} ({body.count(chr(10))} lines).")
+
+
+write_readme_md(nb)


### PR DESCRIPTION
Answers the README question: keeps the notebook flow but eliminates the junk.

## Problem
`README.ipynb` → `README.md` leaked into the README: the Colab bootstrap cell (code + output), pandas DataFrame `<style scoped>` CSS blocks (GitHub strips `<style>` anyway → dead text), and raw `<table>`/`<div>` HTML that renders as ugly bordered tables. **1305 → 574 lines, now 100% HTML-free.**

## Approach — keep the flow, clean the conversion
The notebook earns its keep (Colab-runnable badge, executed *real* outputs, single source of truth), so this keeps it and folds the conversion into `build_readme.py` (one command, no separate `nbconvert` step):
- **Colab cell** tagged `remove_cell` → stays in the `.ipynb` (Colab still auto-installs) but dropped from the `.md` via `TagRemovePreprocessor`.
- **`<style>`** blocks stripped.
- **DataFrame `<table>` HTML → GitHub markdown tables** via a pandas round-trip, flattening MultiIndex / entity `_repr_html_` headers and turning the `N rows × M cols` footer into an italic caption.

Also regenerated against the current API + mentions the new web capabilities (permalinks, export). CLAUDE.md flow note updated; `nbconvert` added to dev-requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)