### PR TITLE
Pin hashstash>=1.0.0,<2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ regex
 munkres
 
 pyarrow
-hashstash
+hashstash>=1.0.0,<2
 tabulate
 # stanza
 plotnine


### PR DESCRIPTION
hashstash was unpinned in requirements.txt (pyproject reads deps from there), so a fresh install pulled whatever was latest. It just had a **major** release — 1.0.0 — with API-affecting changes (the `safe=True` RCE fix, Fraction normalization for cross-version hash stability, lazy per-backend probing).

Verified 1.0.0 against prosodic as a real downstream consumer: imports + parse work, the load-bearing `encode_hash(serialize(...))` identity path is stable (`entity.hash`, `meter.key`), steady-state serialize perf is unchanged, and the old ~245ms first-serialize cold-start is gone (~5ms). Pinning to the 1.x line locks in a verified-compatible version while protecting against a future breaking 2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)