### PR TITLE
README build: scrub tqdm/stderr noise, mark outputs with ↓

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ yapf --style .style.yapf -i <file>
 .venv/bin/python scripts/rime_eval.py               # ROC, AUC, suggested max_dist
 ```
 
-`scripts/build_readme.py` is the single source: it executes the cells, writes `README.ipynb` (canonical, Colab-runnable), then converts to a clean `README.md` in the same run — no separate `nbconvert` step. The conversion drops the Colab-only bootstrap cell (tagged `remove_cell`), strips pandas `<style>` blocks, and round-trips DataFrame `<table>` HTML into GitHub-native markdown tables, so `README.md` stays HTML-free. Edit `build_readme.py`, not `README.ipynb` directly. nbformat regenerates cell UUIDs on every run, so a fresh build always produces a UUID-only `.ipynb` diff — discard it unless content actually changed.
+`scripts/build_readme.py` is the single source: it executes the cells, writes `README.ipynb` (canonical, Colab-runnable), then converts to a clean `README.md` in the same run — no separate `nbconvert` step. Executed outputs are scrubbed of terminal noise (stderr streams dropped, ANSI/tqdm frames stripped — hashstash's progress bars render into notebook outputs because ipykernel pretends to be a TTY) before saving either artifact. The conversion drops the Colab-only bootstrap cell (tagged `remove_cell`), strips pandas `<style>` blocks, round-trips DataFrame `<table>` HTML into GitHub-native markdown tables, and inserts a standalone `↓` between each code block and its output so the boundary is unambiguous. Edit `build_readme.py`, not `README.ipynb` directly. nbformat regenerates cell UUIDs on every run, so a fresh build always produces a UUID-only `.ipynb` diff — discard it unless content actually changed.
 
 ## Architecture
 

--- a/README.ipynb
+++ b/README.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "feceff09",
+   "id": "a580dc0f",
    "metadata": {},
    "source": [
     "# Prosodic 3\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49d43b40",
+   "id": "8f6cb44b",
    "metadata": {},
    "source": [
     "## Install\n",
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44a229a2",
+   "id": "2e05d69e",
    "metadata": {
     "tags": [
      "remove_cell"
@@ -55,13 +55,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "7051736c",
+   "id": "064ae393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:00.909982Z",
-     "iopub.status.busy": "2026-07-04T19:07:00.909739Z",
-     "iopub.status.idle": "2026-07-04T19:07:00.917315Z",
-     "shell.execute_reply": "2026-07-04T19:07:00.916937Z"
+     "iopub.execute_input": "2026-07-05T15:40:50.976877Z",
+     "iopub.status.busy": "2026-07-05T15:40:50.976396Z",
+     "iopub.status.idle": "2026-07-05T15:40:50.986127Z",
+     "shell.execute_reply": "2026-07-05T15:40:50.985621Z"
     },
     "tags": [
      "remove_cell"
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37857090",
+   "id": "7fd3325b",
    "metadata": {},
    "source": [
     "## Quickstart\n",
@@ -107,13 +107,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "b8974771",
+   "id": "8f7e431b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:00.919220Z",
-     "iopub.status.busy": "2026-07-04T19:07:00.919049Z",
-     "iopub.status.idle": "2026-07-04T19:07:03.046495Z",
-     "shell.execute_reply": "2026-07-04T19:07:03.046017Z"
+     "iopub.execute_input": "2026-07-05T15:40:50.988363Z",
+     "iopub.status.busy": "2026-07-05T15:40:50.988189Z",
+     "iopub.status.idle": "2026-07-05T15:40:53.037686Z",
+     "shell.execute_reply": "2026-07-05T15:40:53.037332Z"
     }
    },
    "outputs": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b88c2aef",
+   "id": "ae168362",
    "metadata": {},
    "source": [
     "## Reading texts\n",
@@ -183,13 +183,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d125158a",
+   "id": "26c15ff5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:03.048220Z",
-     "iopub.status.busy": "2026-07-04T19:07:03.048040Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.687847Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.687498Z"
+     "iopub.execute_input": "2026-07-05T15:40:53.039328Z",
+     "iopub.status.busy": "2026-07-05T15:40:53.039174Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.836593Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.836244Z"
     }
    },
    "outputs": [
@@ -197,110 +197,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "short: 1 line(s)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:   0%|          | 0/20307 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:   8%|▊         | 1634/20307 [00:00<00:01, 9792.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  19%|█▉        | 3853/20307 [00:00<00:01, 15508.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  30%|███       | 6103/20307 [00:00<00:00, 18285.35it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  40%|███▉      | 8059/20307 [00:00<00:00, 14569.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  51%|█████     | 10304/20307 [00:00<00:00, 16827.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  62%|██████▏   | 12536/20307 [00:00<00:00, 18421.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  71%|███████▏  | 14511/20307 [00:00<00:00, 14750.34it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  82%|████████▏ | 16753/20307 [00:01<00:00, 16646.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "\u001b[32m[1.79s] Building long text\u001b[0m:  94%|█████████▍| 19082/20307 [00:01<00:00, 18379.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "                                                                                    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "short: 1 line(s)\n",
       "sonnets: 2,155 lines, 154 stanzas\n",
       "single line: Line(num=1, txt=\"Shall I compare thee to a summer's day?\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r"
      ]
     }
    ],
@@ -321,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3998bf8f",
+   "id": "58a2f1da",
    "metadata": {},
    "source": [
     "## The hierarchy: stanzas → lines → words → syllables → phonemes\n",
@@ -332,13 +231,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8f91fd39",
+   "id": "93764a88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.689418Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.689287Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.691471Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.691177Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.838304Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.838059Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.840314Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.840068Z"
     }
    },
    "outputs": [
@@ -362,13 +261,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4b236ea8",
+   "id": "612de2cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.693005Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.692884Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.706997Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.706692Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.841632Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.841532Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.856948Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.856654Z"
     }
    },
    "outputs": [
@@ -519,13 +418,13 @@
        "      <th rowspan=\"2\" valign=\"top\">1</th>\n",
        "      <th rowspan=\"2\" valign=\"top\">dict</th>\n",
        "      <th>1</th>\n",
-       "      <th>was</th>\n",
+       "      <th>wa</th>\n",
        "      <th>'weɪ</th>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <th>ted</th>\n",
+       "      <th>sted</th>\n",
        "      <th>stəd</th>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
@@ -562,13 +461,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a605d588",
+   "id": "e59b745a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.708537Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.708416Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.711037Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.710749Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.858382Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.858295Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.860646Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.860360Z"
     }
    },
    "outputs": [
@@ -595,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dad67a2b",
+   "id": "77131c31",
    "metadata": {},
    "source": [
     "## DataFrame view\n",
@@ -606,13 +505,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a6414661",
+   "id": "43c8ddfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.712451Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.712341Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.717800Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.717559Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.861950Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.861863Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.867382Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.867103Z"
     }
    },
    "outputs": [
@@ -865,13 +764,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f0db7d01",
+   "id": "bcf8e3ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.719110Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.719029Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.721278Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.720986Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.868718Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.868637Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.870870Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.870608Z"
     }
    },
    "outputs": [
@@ -910,7 +809,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b8edba7",
+   "id": "df977fc1",
    "metadata": {},
    "source": [
     "## Metrical parsing\n",
@@ -921,13 +820,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "dc41a9b9",
+   "id": "7a480808",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.722609Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.722493Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.748525Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.748264Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.872072Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.871990Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.902240Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.901954Z"
     }
    },
    "outputs": [
@@ -949,13 +848,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "987f1360",
+   "id": "f1240c54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.750020Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.749927Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.752504Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.752236Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.903713Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.903592Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.906343Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.906083Z"
     }
    },
    "outputs": [
@@ -986,13 +885,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "fae9a189",
+   "id": "7ba7a0a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.753905Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.753806Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.755551Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.755281Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.907628Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.907517Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.909390Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.909114Z"
     }
    },
    "outputs": [
@@ -1013,13 +912,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "50e03836",
+   "id": "fddc4cef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.757028Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.756901Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.759355Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.759091Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.910661Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.910555Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.912796Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.912536Z"
     }
    },
    "outputs": [
@@ -1046,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "740caa4f",
+   "id": "4eb1dd49",
    "metadata": {},
    "source": [
     "## The parsed DataFrame\n",
@@ -1057,13 +956,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "af586d7b",
+   "id": "3d69d155",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.760760Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.760645Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.770230Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.769950Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.914113Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.914004Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.924046Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.923752Z"
     }
    },
    "outputs": [
@@ -1295,7 +1194,7 @@
        "      <td>...</td>\n",
        "      <td>1</td>\n",
        "      <td>s</td>\n",
-       "      <td>was</td>\n",
+       "      <td>wa</td>\n",
        "      <td>'weɪ</td>\n",
        "      <td>True</td>\n",
        "      <td>0</td>\n",
@@ -1319,7 +1218,7 @@
        "      <td>...</td>\n",
        "      <td>1</td>\n",
        "      <td>w</td>\n",
-       "      <td>ted</td>\n",
+       "      <td>sted</td>\n",
        "      <td>stəd</td>\n",
        "      <td>False</td>\n",
        "      <td>0</td>\n",
@@ -1366,8 +1265,8 @@
        "4         1         4         0         1              4          1           1          1.0     True       False  ...         1          w       ni       nɪ       False        0          0   \n",
        "5         1         4         0         2              5          1           1          1.0     True       False  ...         1          s      cle      kəl       False        0          0   \n",
        "6         1         5         0         0              6          1           1          1.0     True       False  ...         1          w       of       ʌv       False        0          0   \n",
-       "7         1         6         0         0              7          1           1          1.0     True       False  ...         1          s      was     'weɪ        True        0          0   \n",
-       "8         1         6         0         1              8          1           1          1.0     True       False  ...         1          w      ted     stəd       False        0          0   \n",
+       "7         1         6         0         0              7          1           1          1.0     True       False  ...         1          s       wa     'weɪ        True        0          0   \n",
+       "8         1         6         0         1              8          1           1          1.0     True       False  ...         1          w     sted     stəd       False        0          0   \n",
        "9         1         7         0         0              9          1           1          1.0     True       False  ...         1          s     time    'taɪm        True        0          0   \n",
        "\n",
        "   *s_unstress  *unres_across  *unres_within  \n",
@@ -1397,13 +1296,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b4cab3f7",
+   "id": "841fbba2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.771504Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.771419Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.773764Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.773465Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.925411Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.925313Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.927658Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.927402Z"
     }
    },
    "outputs": [
@@ -1445,7 +1344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d3698c7",
+   "id": "6eb69d04",
    "metadata": {},
    "source": [
     "## Custom meters\n",
@@ -1456,13 +1355,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b1c2c7b0",
+   "id": "91adf4b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.775246Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.775132Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.777269Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.776928Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.928950Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.928849Z",
+     "iopub.status.idle": "2026-07-05T15:40:54.930646Z",
+     "shell.execute_reply": "2026-07-05T15:40:54.930396Z"
     }
    },
    "outputs": [
@@ -1486,13 +1385,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f78adf67",
+   "id": "23973cba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.778535Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.778432Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.836893Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.836596Z"
+     "iopub.execute_input": "2026-07-05T15:40:54.931879Z",
+     "iopub.status.busy": "2026-07-05T15:40:54.931796Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.000397Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.000120Z"
     }
    },
    "outputs": [
@@ -1500,7 +1399,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Parse(txt='when IN the CHRO ni CLE of WAS ted TIME')\n"
+      "Parse(txt='when IN the CHRO ni CLE of WA sted TIME')\n"
      ]
     }
    ],
@@ -1512,7 +1411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6174d97",
+   "id": "0a922a7b",
    "metadata": {},
    "source": [
     "## Poem-level analysis\n",
@@ -1523,13 +1422,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "f23a04e4",
+   "id": "4d00479c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.838341Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.838231Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.841514Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.841242Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.001817Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.001699Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.005584Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.005353Z"
     }
    },
    "outputs": [
@@ -1559,13 +1458,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "02ffb5c5",
+   "id": "fe34a05d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.843231Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.843080Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.854982Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.854706Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.006864Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.006757Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.018572Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.018297Z"
     }
    },
    "outputs": [
@@ -1586,7 +1485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8b03ffa",
+   "id": "869f80ea",
    "metadata": {},
    "source": [
     "### Rhyme detection\n",
@@ -1597,13 +1496,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "032ef998",
+   "id": "6398c4a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.856450Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.856343Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.858934Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.858601Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.019887Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.019803Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.022086Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.021756Z"
     }
    },
    "outputs": [
@@ -1626,13 +1525,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "ea2ee362",
+   "id": "e79baaac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.860492Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.860369Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.869473Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.869201Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.023366Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.023280Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.032248Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.031918Z"
     }
    },
    "outputs": [
@@ -1655,13 +1554,13 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "e1659d6e",
+   "id": "d0791acb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.870799Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.870710Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.876006Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.875715Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.033893Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.033746Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.038887Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.038639Z"
     }
    },
    "outputs": [
@@ -1683,7 +1582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23bfa850",
+   "id": "3b9ede43",
    "metadata": {},
    "source": [
     "### Named rhyme scheme matching\n",
@@ -1694,13 +1593,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "ddbf3e32",
+   "id": "fd440883",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.877359Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.877271Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.880282Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.879952Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.040149Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.040060Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.042921Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.042675Z"
     }
    },
    "outputs": [
@@ -1735,13 +1634,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "58c77f53",
+   "id": "bc71f912",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.881669Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.881571Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.884896Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.884584Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.044203Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.044109Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.047176Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.046914Z"
     }
    },
    "outputs": [
@@ -1762,7 +1661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a7b585c",
+   "id": "aac34a67",
    "metadata": {},
    "source": [
     "### Tabular summary\n",
@@ -1773,13 +1672,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "d17d1f9e",
+   "id": "88f52458",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.886199Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.886097Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.900876Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.900594Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.048399Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.048301Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.062067Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.061801Z"
     }
    },
    "outputs": [
@@ -1820,7 +1719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b00af675",
+   "id": "8ee055ca",
    "metadata": {},
    "source": [
     "## MaxEnt weight learning\n",
@@ -1831,23 +1730,16 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "c0484999",
+   "id": "acdf9a50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.902229Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.902148Z",
-     "iopub.status.idle": "2026-07-04T19:07:04.919783Z",
-     "shell.execute_reply": "2026-07-04T19:07:04.919495Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.063264Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.063183Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.079468Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.079207Z"
     }
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[93m[1.44s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)\u001b[0m\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1879,7 +1771,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8eea88d",
+   "id": "a464b4a7",
    "metadata": {},
    "source": [
     "## Phrasal stress (optional)\n",
@@ -1895,7 +1787,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "747ad2f7",
+   "id": "1d45cf05",
    "metadata": {},
    "source": [
     "## Save and load\n",
@@ -1906,13 +1798,13 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "568c48fe",
+   "id": "ef3c407c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T19:07:04.921172Z",
-     "iopub.status.busy": "2026-07-04T19:07:04.921080Z",
-     "iopub.status.idle": "2026-07-04T19:07:05.003325Z",
-     "shell.execute_reply": "2026-07-04T19:07:05.002922Z"
+     "iopub.execute_input": "2026-07-05T15:40:55.080786Z",
+     "iopub.status.busy": "2026-07-05T15:40:55.080704Z",
+     "iopub.status.idle": "2026-07-05T15:40:55.155206Z",
+     "shell.execute_reply": "2026-07-05T15:40:55.154922Z"
     }
    },
    "outputs": [
@@ -1920,24 +1812,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "saved files:"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "saved files:\n",
       "  meta.json\n",
       "  parsed.parquet\n",
       "  syll.parquet\n",
-      "  text.txt.gz\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  text.txt.gz\n",
       "\n",
       "reloaded: 14 lines, parse cached? True\n"
      ]
@@ -1960,7 +1839,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55e3c351",
+   "id": "a5ee0615",
    "metadata": {},
    "source": [
     "## Web app\n",
@@ -1978,7 +1857,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1f78ce2",
+   "id": "8c05e965",
    "metadata": {},
    "source": [
     "## Remote client\n",
@@ -2000,7 +1879,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76167cf6",
+   "id": "d9657982",
    "metadata": {},
    "source": [
     "## Further reading\n",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ sonnet.parse()
 print(sonnet.summary())
 ```
 
+↓
+
       #st    #ln  parse        rhyme      #feet    #syll    #parse
     -----  -----  -----------  -------  -------  -------  --------
         1      1  -+-+-+-+-+   a              5       10         1
@@ -94,34 +96,11 @@ print(f"sonnets: {len(shaksonnets.lines):,} lines, {len(shaksonnets.stanzas):,} 
 print(f"single line: {line}")
 ```
 
+↓
+
     short: 1 line(s)
-
-    [32m[1.79s] Building long text[0m:   0%|          | 0/20307 [00:00<?, ?it/s]
-
-    [32m[1.79s] Building long text[0m:   8%|▊         | 1634/20307 [00:00<00:01, 9792.06it/s]
-
-    [32m[1.79s] Building long text[0m:  19%|█▉        | 3853/20307 [00:00<00:01, 15508.92it/s]
-
-    [32m[1.79s] Building long text[0m:  30%|███       | 6103/20307 [00:00<00:00, 18285.35it/s]
-
-    [32m[1.79s] Building long text[0m:  40%|███▉      | 8059/20307 [00:00<00:00, 14569.55it/s]
-
-    [32m[1.79s] Building long text[0m:  51%|█████     | 10304/20307 [00:00<00:00, 16827.48it/s]
-
-    [32m[1.79s] Building long text[0m:  62%|██████▏   | 12536/20307 [00:00<00:00, 18421.13it/s]
-
-    [32m[1.79s] Building long text[0m:  71%|███████▏  | 14511/20307 [00:00<00:00, 14750.34it/s]
-
-    [32m[1.79s] Building long text[0m:  82%|████████▏ | 16753/20307 [00:01<00:00, 16646.55it/s]
-
-    [32m[1.79s] Building long text[0m:  94%|█████████▍| 19082/20307 [00:01<00:00, 18379.62it/s]
-
-                                                                                        
-
     sonnets: 2,155 lines, 154 stanzas
     single line: Line(num=1, txt="Shall I compare thee to a summer's day?")
-
-    
 
 ## The hierarchy: stanzas → lines → words → syllables → phonemes
 
@@ -134,6 +113,8 @@ print(f"line 1 has {len(sonnet.lines[0].wordtokens)} word tokens")
 print(f"first word: {sonnet.lines[0].wordtokens[0]}")
 ```
 
+↓
+
     sonnet has 1 stanzas, 14 lines
     line 1 has 7 word tokens
     first word: WordToken(num=1, txt='When', lang='en', para_num=1, line_num=1, sent_num=1, sentpart_num=1, linepart_num=1)
@@ -142,6 +123,8 @@ print(f"first word: {sonnet.lines[0].wordtokens[0]}")
 # attribute shortcut: text.line1 == text.lines[0]
 sonnet.line1
 ```
+
+↓
 
 **Line**
 
@@ -155,8 +138,8 @@ sonnet.line1
 |            1 |          1 |              1 |          1 |              1 | ...             | ...             | ...            | ...            | ...                   | ...        | ...        | ...        | ...                 |
 |            1 |          1 |              1 |          1 |              1 | 4               | chronicle       | chronicle      | 1              | dict                  | 3          | cle        | kəl        | 0                   |
 |            1 |          1 |              1 |          1 |              1 | 5               | of              | of             | 1              | dict                  | 1          | of         | ʌv         | 0                   |
-|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 1          | was        | 'weɪ       | 0                   |
-|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 2          | ted        | stəd       | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 1          | wa         | 'weɪ       | 0                   |
+|            1 |          1 |              1 |          1 |              1 | 6               | wasted          | wasted         | 1              | dict                  | 2          | sted       | stəd       | 0                   |
 |            1 |          1 |              1 |          1 |              1 | 7               | time            | time           | 1              | dict                  | 1          | time       | 'taɪm      | 0                   |
 *12 rows × 1 columns*
 ```python
@@ -168,6 +151,8 @@ for syll in wordform.syllables:
     for phon in syll.phonemes:
         print(f"    phon: {phon.txt!r}")
 ```
+
+↓
 
     wordform: WordForm(num=1, txt='in', force_ambig_stress=True, ipa_origin='dict')
       syllable: Syllable(num=1, txt='in', ipa='ɪn'), IPA='ɪn', stressed=False, heavy=True
@@ -183,6 +168,8 @@ The whole text is also accessible as a flat per-syllable DataFrame. This is the 
 sonnet.df.head(8)
 ```
 
+↓
+
 |    |   word_num |   line_num |   para_num |   sent_num |   sentpart_num |   linepart_num | word_txt   |   is_punc |   form_idx |   num_forms |   syll_idx | syll_ipa   | syll_text   | is_stressed   | is_heavy   | is_strong   | is_weak   | is_functionword   |
 |---:|-----------:|-----------:|-----------:|-----------:|---------------:|---------------:|:-----------|----------:|-----------:|------------:|-----------:|:-----------|:------------|:--------------|:-----------|:------------|:----------|:------------------|
 |  0 |          1 |          1 |          1 |          1 |              1 |              1 | When       |         0 |          0 |           2 |          0 | wɛn        | When        | False         | True       | False       | False     | True              |
@@ -197,6 +184,8 @@ sonnet.df.head(8)
 # columns
 list(sonnet.df.columns)
 ```
+
+↓
 
     ['word_num',
      'line_num',
@@ -228,6 +217,8 @@ line.parse()
 print(line.best_parse)
 ```
 
+↓
+
     Parse(txt="shall I com PARE thee TO a SUM mer's DAY")
 
 ```python
@@ -240,6 +231,8 @@ print(f"feet:      {bp.feet}")
 print(f"foot_type: {bp.foot_type}    (per-parse classification)")
 print(f"is_rising: {bp.is_rising}")
 ```
+
+↓
 
     meter:     -+-+-+-+-+    (- = weak, + = strong)
     stress:    ---+---+-+    (- = unstressed, + = stressed)
@@ -254,6 +247,8 @@ for p in line.parses.unbounded:
     print(f"{p.meter_str}  score={p.score}")
 ```
 
+↓
+
     -+-+-+-+-+  score=2.0
 
 ```python
@@ -263,6 +258,8 @@ for line in sonnet.lines[:6]:
     bp = line.best_parse
     print(f"L{line.num:2d}  {bp.meter_str}  score={bp.score:.1f}  ambig={len(line.parses.unbounded)}")
 ```
+
+↓
 
     L 1  -+-+-+-+-+  score=1.0  ambig=1
     L 2  -+-+-+-+-+  score=1.0  ambig=1
@@ -279,6 +276,8 @@ Per-syllable parse results across the whole text — useful for analysis, plotti
 sonnet.parsed_df.head(10)
 ```
 
+↓
+
 |    |   line_num |   word_num |   form_idx |   syll_idx |   line_syll_idx |   parse_idx |   parse_rank |   parse_score | is_best   | is_bounded   | ...   |   pos_size | meter_val   | syll_txt   | syll_ipa   | is_stressed   |   *w_peak |   *w_stress |   *s_unstress |   *unres_across |   *unres_within |
 |---:|-----------:|-----------:|-----------:|-----------:|----------------:|------------:|-------------:|--------------:|:----------|:-------------|:------|-----------:|:------------|:-----------|:-----------|:--------------|----------:|------------:|--------------:|----------------:|----------------:|
 |  0 |          1 |          1 |          0 |          0 |               0 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | When       | wɛn        | False         |         0 |           0 |             0 |               0 |               0 |
@@ -288,14 +287,16 @@ sonnet.parsed_df.head(10)
 |  4 |          1 |          4 |          0 |          1 |               4 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | ni         | nɪ         | False         |         0 |           0 |             0 |               0 |               0 |
 |  5 |          1 |          4 |          0 |          2 |               5 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | cle        | kəl        | False         |         0 |           0 |             1 |               0 |               0 |
 |  6 |          1 |          5 |          0 |          0 |               6 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | of         | ʌv         | False         |         0 |           0 |             0 |               0 |               0 |
-|  7 |          1 |          6 |          0 |          0 |               7 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | was        | 'weɪ       | True          |         0 |           0 |             0 |               0 |               0 |
-|  8 |          1 |          6 |          0 |          1 |               8 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | ted        | stəd       | False         |         0 |           0 |             0 |               0 |               0 |
+|  7 |          1 |          6 |          0 |          0 |               7 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | wa         | 'weɪ       | True          |         0 |           0 |             0 |               0 |               0 |
+|  8 |          1 |          6 |          0 |          1 |               8 |           1 |            1 |             1 | True      | False        | ...   |          1 | w           | sted       | stəd       | False         |         0 |           0 |             0 |               0 |               0 |
 |  9 |          1 |          7 |          0 |          0 |               9 |           1 |            1 |             1 | True      | False        | ...   |          1 | s           | time       | 'taɪm      | True          |         0 |           0 |             0 |               0 |               0 |
 *10 rows × 21 columns*
 ```python
 # every column you might want for analysis
 list(sonnet.parsed_df.columns)
 ```
+
+↓
 
     ['line_num',
      'word_num',
@@ -332,6 +333,8 @@ strict = prosodic.Meter(
 print(strict)
 ```
 
+↓
+
     Meter(constraints={'w_peak': 1.0, 'w_stress': 1.0, 's_unstress': 1.0, 'foot_size': 1.0}, max_s=1, max_w=1, resolve_optionality=True, parse_unit='line')
 
 ```python
@@ -340,7 +343,9 @@ sonnet.parse(meter=strict)
 print(sonnet.line1.best_parse)
 ```
 
-    Parse(txt='when IN the CHRO ni CLE of WAS ted TIME')
+↓
+
+    Parse(txt='when IN the CHRO ni CLE of WA sted TIME')
 
 ## Poem-level analysis
 
@@ -350,6 +355,8 @@ Prosodic 3 includes `prosodic/analysis/` (a port of the standalone [poesy](https
 # meter classification (iambic / trochaic / anapestic / dactylic)
 sonnet.meter_type
 ```
+
+↓
 
     {'foot': 'binary',
      'head': 'final',
@@ -366,6 +373,8 @@ print('feet  scheme:', sonnet.line_scheme)
 print('syll  scheme:', sonnet.syllable_scheme)
 ```
 
+↓
+
     feet  scheme: {'combo': (5,), 'diff': 2}
     syll  scheme: {'combo': (10,), 'diff': 1}
 
@@ -378,6 +387,8 @@ Rhyme is computed via feature-weighted edit distance over IPA segments (panphon)
 sonnet.line1.rime_distance(sonnet.lines[2])  # 'time' vs 'rhyme'
 ```
 
+↓
+
     0.0
 
 ```python
@@ -385,6 +396,8 @@ sonnet.line1.rime_distance(sonnet.lines[2])  # 'time' vs 'rhyme'
 for line, (dist, partner) in list(sonnet.get_rhyming_lines().items())[:6]:
     print(f"L{line.num:2d} ↔ L{partner.num:2d}  dist={dist:.2f}  '{line.txt.strip()[:35]}' / '{partner.txt.strip()[:35]}'")
 ```
+
+↓
 
     L 3 ↔ L 1  dist=0.00  'And beauty making beautiful old rhy' / 'When in the chronicle of wasted tim'
     L 8 ↔ L 6  dist=0.00  'Even such a beauty as you master no' / 'Of hand, of foot, of lip, of eye, o'
@@ -396,6 +409,8 @@ print('IDs:    ', sonnet.rhyme_ids)
 from prosodic.analysis import nums_to_scheme
 print('letters:', ''.join(nums_to_scheme(sonnet.rhyme_ids)))
 ```
+
+↓
 
     IDs:     [1, 2, 1, 2, 0, 3, 0, 3, 0, 4, 5, 4, 5, 5]
     letters: abab-c-c-dedee
@@ -415,6 +430,8 @@ for name, form, score in rs['candidates'][:5]:
     print(f"  {score:.2f}  {name:30s} {form}")
 ```
 
+↓
+
     name:     Sonnet A
     form:     abab cdcd eefeff
     accuracy: 0.70
@@ -432,6 +449,8 @@ print('is_sonnet:               ', sonnet.is_sonnet)
 print('is_shakespearean_sonnet: ', sonnet.is_shakespearean_sonnet)
 ```
 
+↓
+
     is_sonnet:                True
     is_shakespearean_sonnet:  False
 
@@ -442,6 +461,8 @@ print('is_shakespearean_sonnet: ', sonnet.is_shakespearean_sonnet)
 ```python
 print(sonnet.summary())
 ```
+
+↓
 
       #st    #ln  parse        rhyme      #feet    #syll    #parse
     -----  -----  -----------  -------  -------  -------  --------
@@ -485,7 +506,7 @@ for name, w in sorted(meter.zone_weights.items(), key=lambda x: -abs(x[1]))[:8]:
     print(f"  {w:+.3f}  {name}")
 ```
 
-    [93m[1.44s] prosodic.parsing.maxent.MaxEntTrainer._build_line_data(): 1/14 lines had no matching scansion among parser candidates (syllable count mismatch?)[0m
+↓
 
     top learned weights (zone × constraint):
       +5.069  unres_within_z3
@@ -526,14 +547,13 @@ print(f'\nreloaded: {len(loaded.lines)} lines, parse cached?',
 shutil.rmtree(out)
 ```
 
-    saved files:
+↓
 
-    
+    saved files:
       meta.json
       parsed.parquet
       syll.parquet
       text.txt.gz
-
     
     reloaded: 14 lines, parse cached? True
 

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -340,6 +340,55 @@ nb["cells"] = cells
 client = NotebookClient(nb, timeout=300, kernel_name="python3")
 client.execute(cwd=str(REPO_ROOT))
 
+
+def scrub_outputs(nb):
+    """Remove terminal noise from executed cell outputs.
+
+    hashstash's progress_bar passes disable=None to tqdm (auto-off when not a
+    TTY), but ipykernel's stream pretends to be a TTY so the bars render into
+    cell outputs as ANSI-colored carriage-return frames. Drop stderr streams
+    wholesale (progress + log noise, never README content) and strip ANSI
+    escapes / stray tqdm frames from what remains. Cleans both the saved
+    README.ipynb and the markdown derived from it.
+    """
+    import re
+
+    ansi = re.compile(r"\x1b\[[0-9;]*m")
+    tqdm_frame = re.compile(r"^.*\d+%\|.*(\||\])\s*(\[.*it/s\]?)?\s*$")
+
+    for cell in nb["cells"]:
+        if cell.get("cell_type") != "code":
+            continue
+        kept = []
+        for out in cell.get("outputs", []):
+            if out.get("output_type") == "stream":
+                if out.get("name") == "stderr":
+                    continue
+                text = ansi.sub("", "".join(out.get("text", "")))
+                lines = [
+                    ln for ln in text.split("\n")
+                    if not tqdm_frame.match(ln.replace("\r", ""))
+                ]
+                text = "\n".join(lines)
+                if not text.strip():
+                    continue
+                out["text"] = text
+                # coalesce with a preceding stdout chunk (removing the
+                # interleaved stderr leaves stdout split mid-block, which
+                # renders with spurious blank lines)
+                if (
+                    kept
+                    and kept[-1].get("output_type") == "stream"
+                    and kept[-1].get("name") == "stdout"
+                ):
+                    kept[-1]["text"] = kept[-1]["text"].rstrip("\n") + "\n" + text
+                    continue
+            kept.append(out)
+        cell["outputs"] = kept
+
+
+scrub_outputs(nb)
+
 # Save notebook (canonical, Colab-runnable)
 out_path = REPO_ROOT / "README.ipynb"
 with out_path.open("w") as f:
@@ -356,11 +405,25 @@ def write_readme_md(nb):
     round-trip the DataFrame tables back through pandas into GitHub-native
     markdown tables.
     """
+    import copy
     import io
     import re
     import pandas as pd
     from nbconvert import MarkdownExporter
     from traitlets.config import Config
+
+    # Mark code→output boundaries (hashstash-README style): inject a sentinel
+    # stream line as each cell's first output, then rewrite it to a standalone
+    # "↓" after conversion. Without it, indented output blocks are visually
+    # ambiguous with the code fence above them.
+    ARROW = "@@OUTPUT-ARROW@@"
+    nb = copy.deepcopy(nb)
+    for cell in nb["cells"]:
+        if cell.get("cell_type") == "code" and cell.get("outputs"):
+            cell["outputs"].insert(
+                0,
+                nbformat.v4.new_output("stream", name="stdout", text=ARROW + "\n"),
+            )
 
     cfg = Config()
     cfg.TagRemovePreprocessor.remove_cell_tags = ("remove_cell",)
@@ -369,6 +432,9 @@ def write_readme_md(nb):
         "nbconvert.preprocessors.TagRemovePreprocessor"
     ]
     body, _ = MarkdownExporter(config=cfg).from_notebook_node(nb)
+
+    # sentinel (rendered as an indented output line) -> standalone arrow
+    body = re.sub(rf"\n( {{4}}{ARROW}\n+|{ARROW}\n+)", "\n\n↓\n\n", body)
 
     # pandas DataFrame CSS is dead weight (GitHub ignores <style>)
     body = re.sub(r"<style.*?</style>", "", body, flags=re.DOTALL)


### PR DESCRIPTION
Fixes the tqdm junk in the Reading-texts section (`Building long text: 0%|…` ANSI frames) and makes code→output boundaries explicit.

**Root cause**: hashstash's `progress_bar` passes `disable=None` to tqdm — auto-disable when stderr isn't a TTY — but ipykernel's stream *claims* to be a TTY (so libraries emit colors), so progress bars render into notebook outputs during the build.

**Fix**: `scrub_outputs()` in `build_readme.py` runs after execution, before saving either artifact:
- drops stderr stream outputs wholesale (progress bars, loguru warnings — never README content)
- strips ANSI escapes and stray tqdm frames from stdout
- coalesces stdout chunks that the removed stderr had split (they rendered as spurious blank lines)

**Presentation**: adopts the hashstash README convention — a standalone `↓` between each code block and its indented output, so the boundary is unambiguous. Implemented by injecting a sentinel stream output per cell into a deep copy of the notebook and rewriting it post-conversion.

The rebuild also bakes in the g2p-aligned syllable labels from #131 (`wa|sted` for weɪ|stəd, `WA sted TIME` in parse output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3WDdViUY6ey21JHB2mQB