### PR TITLE
Add TextModel.line_num_sylls public accessor; document viold nonzero-only

### DIFF
--- a/prosodic/analysis/form.py
+++ b/prosodic/analysis/form.py
@@ -9,9 +9,7 @@ from typing import Dict, Optional
 
 
 def _canonical_sylls(text):
-    df = text._syll_df
-    canonical = df[(df["form_idx"] == 0) & (~df["is_punc"])]
-    return canonical.groupby("line_num").size().to_dict()
+    return text.line_num_sylls
 
 
 def is_sonnet(text, meter_type: Optional[Dict] = None,

--- a/prosodic/analysis/summary.py
+++ b/prosodic/analysis/summary.py
@@ -9,15 +9,13 @@ from .rhyme_scheme import compute_rhyme_ids, match_rhyme_scheme, nums_to_scheme
 
 
 def _line_metadata(text):
-    """Per-line stanza number + canonical syll count from _syll_df.
+    """Per-line stanza number + canonical syll count.
 
     Canonical = form_idx==0 (first pronunciation). Avoids over-counting from
     pronunciation variants, which would otherwise inflate ``num_sylls``.
     """
-    df = text._syll_df
-    canonical = df[(df["form_idx"] == 0) & (~df["is_punc"])]
-    syll_counts = canonical.groupby("line_num").size().to_dict()
-    stanza_map = df.groupby("line_num")["para_num"].first().to_dict()
+    syll_counts = text.line_num_sylls
+    stanza_map = text._syll_df.groupby("line_num")["para_num"].first().to_dict()
     return syll_counts, stanza_map
 
 

--- a/prosodic/parsing/positions.py
+++ b/prosodic/parsing/positions.py
@@ -93,6 +93,14 @@ class ParsePosition(Entity):
 
     @property
     def viold(self):
+        """Constraint name -> violation count summed over this position's slots.
+
+        NOTE: on DF-path parses (``text.parse()``), slot viold dicts contain
+        only the NONZERO violations recorded by the vectorized parser — a
+        constraint that isn't violated is simply absent, not present with 0.
+        Iterate ``meter.constraints`` (or tally against position counts) if
+        you need zero-filled rates.
+        """
         viold = Counter()
         for slot in self.slots:
             for cname,cviol in slot.viold.items():

--- a/prosodic/texts/texts.py
+++ b/prosodic/texts/texts.py
@@ -825,13 +825,27 @@ class TextModel(Entity):
         return {"combo": combo, "diff": diff}
 
     @cached_property
+    def line_num_sylls(self):
+        """Canonical per-line syllable counts: dict of line_num -> int.
+
+        Canonical = the first pronunciation of each word (form_idx==0),
+        punctuation excluded. Use this rather than ``line.num_sylls``, which
+        counts syllables across ALL pronunciation variants and inflates the
+        total for words with multiple wordforms.
+        """
+        df = self._syll_df
+        canonical = df[(df["form_idx"] == 0) & (~df["is_punc"])]
+        return {
+            int(k): int(v)
+            for k, v in canonical.groupby("line_num").size().items()
+        }
+
+    @cached_property
     def syllable_scheme(self):
         """Repeating syllable-length template (canonical sylls, form_idx==0)."""
         from ..analysis.line_scheme import detect_line_scheme
-        df = self._syll_df
-        canonical = df[(df["form_idx"] == 0) & (~df["is_punc"])]
-        sylls_by_line = canonical.groupby("line_num").size().to_dict()
-        sylls = [int(sylls_by_line.get(line.num, 0)) for line in self.lines]
+        sylls_by_line = self.line_num_sylls
+        sylls = [sylls_by_line.get(line.num, 0) for line in self.lines]
         combo, diff = detect_line_scheme(sylls, beat=False)
         return {"combo": combo, "diff": diff}
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -147,6 +147,15 @@ def test_text_summary(sonnet):
     assert "Pentameter" in s
 
 
+def test_line_num_sylls(sonnet):
+    # Public accessor for canonical per-line syllable counts (used by poesy).
+    counts = sonnet.line_num_sylls
+    assert set(counts) == {line.num for line in sonnet.lines}
+    assert all(isinstance(v, int) for v in counts.values())
+    # sonnet 106 is pentameter: canonical counts hover around 10
+    assert 9 <= sorted(counts.values())[len(counts) // 2] <= 11
+
+
 # ----------------------------------------------------------- non-sonnet
 
 


### PR DESCRIPTION
Two small changes requested by the poesy 0.4 shim work (quadrismegistus/poesy#8):

1. **`TextModel.line_num_sylls`** — public cached property returning canonical per-line syllable counts (`{line_num: int}`, form_idx==0, punctuation excluded). poesy and three internal sites (`analysis/form.py`, `analysis/summary.py`, `syllable_scheme`) were all hand-rolling the same `_syll_df` filter; they now share this accessor. Documented against the `line.num_sylls` variant-inflation gotcha.
2. **`ParsePosition.viold` docstring** — notes that DF-path parses record only nonzero violations (absent ≠ zero), which bit the poesy shim when computing violation rates.

New test for the accessor; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF3WDdViUY6ey21JHB2mQB