### PR TITLE
Release via PyPI Trusted Publishing (OIDC) instead of token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,24 +28,26 @@ jobs:
           prerelease: false
           title: "Release ${{ github.ref_name }}"
 
+  # Publishes via PyPI Trusted Publishing (OIDC) — no long-lived token.
+  # PyPI side: project prosodic → Settings → Publishing → GitHub publisher
+  # (owner quadrismegistus, repo prosodic, workflow release.yml, env pypi).
+  # The old PYPI_API_TOKEN secret is unused and can be deleted.
   pypi-release:
     name: "PyPI Release"
     needs: [tests, pre-release]
     runs-on: "ubuntu-latest"
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Build
         run: |
-          python -m pip install --upgrade pip
-          pip install build twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
+          python -m pip install --upgrade pip build
           python -m build
-          twine upload dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Migrates the release workflow off the long-lived `PYPI_API_TOKEN` secret to PyPI Trusted Publishing (OIDC), matching the flow that just shipped poesy 0.4.0: `pypa/gh-action-pypi-publish` with `id-token: write`, running in the `pypi` GitHub environment (created).

**Merge only after** the trusted publisher is added on PyPI (project prosodic → Settings → Publishing → GitHub: owner `quadrismegistus`, repo `prosodic`, workflow `release.yml`, environment `pypi`) — otherwise the next `v*` tag push fails at the publish step. Once merged and verified on the next release, delete the `PYPI_API_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)