### PR TITLE
Add Hayes-style metrical grid — first cadence port

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,24 +28,26 @@ jobs:
           prerelease: false
           title: "Release ${{ github.ref_name }}"
 
+  # Publishes via PyPI Trusted Publishing (OIDC) — no long-lived token.
+  # PyPI side: project prosodic → Settings → Publishing → GitHub publisher
+  # (owner quadrismegistus, repo prosodic, workflow release.yml, env pypi).
+  # The old PYPI_API_TOKEN secret is unused and can be deleted.
   pypi-release:
     name: "PyPI Release"
     needs: [tests, pre-release]
     runs-on: "ubuntu-latest"
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Build
         run: |
-          python -m pip install --upgrade pip
-          pip install build twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
+          python -m pip install --upgrade pip build
           python -m build
-          twine upload dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,8 +14,11 @@ live smoke test, 2026-07-05). Portable, in rough order of value-per-effort:
 
 - **Hayes-style metrical grid view** — cadence's `sent.grid()` renders a
   plotnine stress grid over syllables; small and pedagogically excellent.
-  Natural home: Line View tab in the web app (long on the wishlist) plus a
-  `line.grid()` / `text.grid()` API. Most likely port.
+  ✅ API shipped (`analysis/grid.py`: `line.grid_str()` / `grid_df()` /
+  `grid_plot()`, works on both parse paths). Remaining: render the grid in
+  the web app's Line View tab (see "Parse table design polish" below), and
+  a phrasal-prominence row once continuous phrasal stress exists (see
+  MetricalTree item — the grid API takes extra rows without change).
 - **nltk.Tree / svgling export** — cadence's metrical tree is an `nltk.Tree`
   subclass, so svgling SVG rendering came free. If v3 exports its
   phrasal-stress structure as `nltk.Tree` (`to_nltk_tree()`), notebook SVG

--- a/prosodic/analysis/__init__.py
+++ b/prosodic/analysis/__init__.py
@@ -4,6 +4,7 @@ Most users won't import from here directly — these are wired onto ``TextModel`
 as properties (``text.meter_type``, ``text.rhyme_scheme``, ``text.summary()``).
 """
 from .form import is_shakespearean_sonnet, is_sonnet
+from .grid import grid_data, grid_df, grid_plot, grid_str
 from .line_scheme import (
     BEAT_NAMES,
     detect_line_scheme,
@@ -25,6 +26,10 @@ __all__ = [
     "classify_meter_type",
     "compute_rhyme_ids",
     "detect_line_scheme",
+    "grid_data",
+    "grid_df",
+    "grid_plot",
+    "grid_str",
     "is_shakespearean_sonnet",
     "is_sonnet",
     "load_named_schemes",

--- a/prosodic/analysis/grid.py
+++ b/prosodic/analysis/grid.py
@@ -1,0 +1,125 @@
+"""Hayes-style metrical grid over a parsed line.
+
+A metrical grid (Liberman & Prince 1977; Hayes 1983) stacks marks over
+syllables: column height encodes linguistic prominence. Here the grid rows
+are, bottom-up: every syllable, lexically stressed syllables (primary or
+secondary), primary-stressed syllables. The metrical template is NOT mixed
+into the mark columns (that would put gaps in them); it appears as a w/s
+annotation row beneath the syllable text, so a stress/meter mismatch reads
+as a tall column over a ``w`` — exactly the mismatch the parser's
+constraints penalize. Positions whose best parse incurred violations are
+flagged with ``*`` after the meter letter.
+
+Ported in spirit from cadence's ``sent.grid()`` (see ROADMAP.md).
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+
+def grid_data(parse) -> List[dict]:
+    """Per-syllable grid rows for a parse.
+
+    Returns a list of dicts, one per syllable in order:
+    ``txt``, ``stress`` ('P'/'S'/'U'), ``meter`` ('s'/'w'),
+    ``height`` (1=syllable, 2=+stressed, 3=+primary), ``viol`` (bool:
+    the containing position has violations).
+    """
+    rows = []
+    for pos in parse.positions:
+        viol = bool(pos.violset)
+        for slot in pos.slots:
+            unit = slot.unit
+            stress = getattr(unit, "stress", "U") or "U"
+            height = 1 + (stress in ("P", "S")) + (stress == "P")
+            rows.append({
+                # slot.txt renders case by metrical prominence (STRONG/weak)
+                "txt": slot.txt.strip(),
+                "stress": stress,
+                "meter": pos.meter_val,
+                "height": height,
+                "viol": viol,
+            })
+    return rows
+
+
+def grid_str(parse, mark: str = "*", viols: bool = True) -> str:
+    """Render the grid as monospace text.
+
+    Example::
+
+                                *
+            *       *       *   *        *
+        *   *   *   *   *   *   *   *    *   *
+        when IN  the CHRO ni  CLE  of  WA sted TIME
+        w    s   w   s    w   s   w   s  w    s
+    """
+    rows = grid_data(parse)
+    if not rows:
+        return ""
+    widths = [max(len(r["txt"]), 1) for r in rows]
+    max_h = max(r["height"] for r in rows)
+
+    def cell(content, w):
+        return content.ljust(w)
+
+    lines = []
+    for level in range(max_h, 0, -1):
+        lines.append(" ".join(
+            cell(mark if r["height"] >= level else "", w)
+            for r, w in zip(rows, widths)
+        ).rstrip())
+    lines.append(" ".join(cell(r["txt"], w) for r, w in zip(rows, widths)).rstrip())
+    lines.append(" ".join(
+        cell(r["meter"] + ("*" if viols and r["viol"] else ""), w)
+        for r, w in zip(rows, widths)
+    ).rstrip())
+    return "\n".join(lines)
+
+
+def grid_df(parse):
+    """Grid as a DataFrame: one row per syllable with prominence levels."""
+    import pandas as pd
+
+    df = pd.DataFrame(grid_data(parse))
+    df.index.name = "syll_i"
+    return df
+
+
+def grid_plot(parse, mark_size: int = 6):
+    """Grid as a plotnine figure: mark stacks over syllable labels.
+
+    Returns a ``plotnine.ggplot``; display it in a notebook or ``.save()`` it.
+    """
+    import pandas as pd
+    from plotnine import (
+        aes, element_blank, geom_point, geom_text, ggplot, labs,
+        scale_x_continuous, scale_y_continuous, theme, theme_minimal,
+    )
+
+    rows = grid_data(parse)
+    marks = [
+        {"x": i, "y": level, "meter": r["meter"]}
+        for i, r in enumerate(rows)
+        for level in range(1, r["height"] + 1)
+    ]
+    labels = [
+        {"x": i, "y": 0,
+         "label": r["txt"] + ("\n" + r["meter"] + ("*" if r["viol"] else ""))}
+        for i, r in enumerate(rows)
+    ]
+    p = (
+        ggplot(pd.DataFrame(marks), aes("x", "y"))
+        + geom_point(size=mark_size, shape="*")
+        + geom_text(aes("x", "y", label="label"), data=pd.DataFrame(labels), size=8)
+        + scale_y_continuous(limits=(-0.5, max(r["height"] for r in rows) + 0.5))
+        + scale_x_continuous(limits=(-0.5, len(rows) - 0.5))
+        + theme_minimal()
+        + theme(
+            axis_text=element_blank(),
+            axis_ticks=element_blank(),
+            panel_grid=element_blank(),
+        )
+        + labs(x="", y="")
+    )
+    return p

--- a/prosodic/parsing/parses.py
+++ b/prosodic/parsing/parses.py
@@ -481,6 +481,21 @@ class Parse(Entity):
         """
         return len([mpos for mpos in self.positions if mpos.is_prom])
 
+    def grid_str(self, **kwargs) -> str:
+        """Hayes-style metrical grid as monospace text (see analysis.grid)."""
+        from ..analysis.grid import grid_str
+        return grid_str(self, **kwargs)
+
+    def grid_df(self):
+        """Metrical grid as a per-syllable DataFrame (see analysis.grid)."""
+        from ..analysis.grid import grid_df
+        return grid_df(self)
+
+    def grid_plot(self, **kwargs):
+        """Metrical grid as a plotnine figure (see analysis.grid)."""
+        from ..analysis.grid import grid_plot
+        return grid_plot(self, **kwargs)
+
     @property
     def is_rising(self) -> Optional[bool]:
         """

--- a/prosodic/texts/lines.py
+++ b/prosodic/texts/lines.py
@@ -148,6 +148,18 @@ class Line(WordTokenList):
         """
         return len(self.syllables)
 
+    def grid_str(self, **kwargs) -> str:
+        """Hayes-style metrical grid of the best parse as monospace text."""
+        return self.best_parse.grid_str(**kwargs)
+
+    def grid_df(self):
+        """Metrical grid of the best parse as a per-syllable DataFrame."""
+        return self.best_parse.grid_df()
+
+    def grid_plot(self, **kwargs):
+        """Metrical grid of the best parse as a plotnine figure."""
+        return self.best_parse.grid_plot(**kwargs)
+
     @cache
     def rime_distance(self, line: 'Line', max_dist=RHYME_MAX_DIST) -> float:
         """

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,71 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from prosodic.imports import *
+from prosodic.analysis import grid_data, grid_df, grid_str
+
+disable_caching()
+
+LINE = "When in the chronicle of wasted time"
+
+
+@pytest.fixture(scope="module")
+def parsed_line():
+    t = TextModel(LINE)
+    t.parse()
+    return t.lines[0]
+
+
+def test_grid_data_rows(parsed_line):
+    rows = grid_data(parsed_line.best_parse)
+    assert len(rows) == 10  # pentameter line
+    assert [r["meter"] for r in rows] == list("wswswswsws")
+    # primary-stressed syllables get full-height columns
+    by_txt = {r["txt"]: r for r in rows}
+    assert by_txt["IN"]["height"] == 3
+    assert by_txt["when"]["height"] == 1
+    # the s_unstress violation on "CLE" is flagged on its position
+    assert by_txt["CLE"]["viol"] is True
+
+
+def test_grid_str_shape(parsed_line):
+    s = parsed_line.grid_str()
+    lines = s.split("\n")
+    # marks rows + syllable text row + meter row
+    assert lines[-2].split() == ["when", "IN", "the", "CHRO", "ni", "CLE", "of", "WA", "sted", "TIME"]
+    meter_row = lines[-1].split()
+    assert meter_row[0] == "w" and meter_row[1] == "s"
+    assert "s*" in meter_row  # violation marker
+    # bottom marks row has one mark per syllable
+    assert lines[-3].count("*") == 10
+
+
+def test_grid_str_no_viols_flag(parsed_line):
+    s = parsed_line.grid_str(viols=False)
+    assert "s*" not in s.split("\n")[-1]
+
+
+def test_grid_df(parsed_line):
+    df = parsed_line.grid_df()
+    assert list(df.columns) == ["txt", "stress", "meter", "height", "viol"]
+    assert len(df) == 10
+    assert df["height"].between(1, 3).all()
+
+
+def test_grid_entity_path_matches_df_path(parsed_line):
+    from prosodic.parsing.meter import Meter
+    from prosodic.parsing.vectorized import parse_batch
+
+    t2 = TextModel(LINE)
+    parse_batch(t2.lines, Meter())
+    assert t2.lines[0].best_parse.grid_str() == parsed_line.grid_str()
+
+
+def test_grid_plot(parsed_line):
+    plotnine = pytest.importorskip("plotnine")
+    p = parsed_line.grid_plot()
+    assert isinstance(p, plotnine.ggplot)


### PR DESCRIPTION
First ROADMAP item: the metrical grid API (`analysis/grid.py`), ported in spirit from cadence's `sent.grid()`.

```
     *      *              *       *
     *      *              *       *
*    *  *   *    *  *   *  *  *    *
when IN the CHRO ni CLE of WA sted TIME
w    s  w   s    w  s*  w  s  w    s
```

- Mark columns encode **linguistic prominence** (row 1: every syllable; row 2: stressed; row 3: primary) — no gaps in columns, per Hayes; the metrical template stays out of the stacks and appears as the `w`/`s` row beneath, with `*` flagging positions that incurred violations. A stress/meter mismatch reads as a tall column over a `w`.
- Three renderers: `grid_str()` (monospace text), `grid_df()` (per-syllable DataFrame), `grid_plot()` (plotnine, already a dependency).
- Wired as `Parse.grid_str/grid_df/grid_plot` + `Line` delegates to `best_parse`; identical output on both parse paths (DF and entity — covered by test).
- Extension points reserved: phrasal-prominence rows (dep-tree now, MetricalTree-proper later) add rows without API change; web Line View rendering is the remaining half of the roadmap item.

6 new tests; full suite 344 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)