### PR TITLE
Gradient phrasal constraints (*_p/*_t) + methods documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,12 @@ TextModel → Stanza → Line → WordToken → WordType → WordForm → Syllab
 
 ### Metrical Parsing (`parsing/`)
 
+Theory + implementation write-up: [`methods/metrical-parsing.md`](methods/metrical-parsing.md).
+
 The parser is always vectorized and exhaustive — it evaluates ALL possible scansions via numpy and uses harmonic bounding to identify optimal parses.
 
 - **Meter** (`meter.py`): Configuration object with constraints, max strong/weak positions (`max_s`, `max_w`). The `exhaustive` and `vectorized` params are accepted but ignored (always both).
-- **Constraints** (`constraints.py`): Each constraint has a `@constraint` decorator with `desc`, `scope`, and optional `vectorized` lambda. The vectorized lambda receives broadcast feature arrays and returns `(L, S, N)` int8 violations — this is what runs during parsing. The entity-based function body is a reference implementation used only by manually-constructed Parse objects. Default constraints: `w_stress`, `s_unstress`, `unres_within`, `unres_across`, `w_peak`, `foot_size`. Additional: `s_trough`, `clash`, `lapse`, `w_heavy`, `s_light`, `s_func`, `word_foot`. Phrasal stress constraints (require `syntax=True`): `w_prom`, `s_demoted`. Adding a new constraint = one decorated function in `constraints.py` with a `vectorized` lambda; no changes to `vectorized.py` needed.
+- **Constraints** (`constraints.py`): Each constraint has a `@constraint` decorator with `desc`, `scope`, and optional `vectorized` lambda. The vectorized lambda receives broadcast feature arrays and returns `(L, S, N)` int8 violations — this is what runs during parsing. The entity-based function body is a reference implementation used only by manually-constructed Parse objects. Default constraints: `w_stress`, `s_unstress`, `unres_within`, `unres_across`, `w_peak`, `foot_size`. Additional: `s_trough`, `clash`, `lapse`, `w_heavy`, `s_light`, `s_func`, `word_foot`. Phrasal stress constraints (require `syntax=True`): `w_prom`, `s_demoted` (discrete depth), `w_stress_p`, `s_unstress_p`, `w_stress_t`, `s_unstress_t` (gradient MetricalTree values; cadence's *_p/*_t variants). Adding a new constraint = one decorated function in `constraints.py` with a `vectorized` lambda; no changes to `vectorized.py` needed.
 - **Parse** (`parses.py`): A single candidate parse. Ranked by weighted violation score; `best_parse` = lowest score among unbounded.
 - **LazyParseList** (`vectorized.py`): Stores numpy violation data. Parse objects built only on access. `.unbounded` returns sorted by score. `.best_parse` uses `argmin` — no sorting needed.
 
@@ -101,6 +103,8 @@ The parser is always vectorized and exhaustive — it evaluates ALL possible sca
 
 ### Phrasal Stress (`texts/phrasal_stress.py`)
 
+Theory + lineage write-up (Dozat's MetricalTree, cadence, our dep-projection port): [`methods/phrasal-stress.md`](methods/phrasal-stress.md).
+
 Optional dependency-parse-based phrasal prominence (Liberman & Prince 1977). Uses spaCy dep-only parsing — no constituency trees needed.
 
 - **`TextModel("...", syntax=True)`**: enables phrasal stress computation. Adds `phrasal_stress` column to `_syll_df`.
@@ -108,7 +112,7 @@ Optional dependency-parse-based phrasal prominence (Liberman & Prince 1977). Use
 - **Values**: 0 = sentence root (most prominent), -1 = direct dependent, -2 to -6 = deeper embedding. `<NA>` for punctuation.
 - **Gradient values** (`pstress`, `tstress` columns, MetricalTree port): Dozat's metrical-tree algorithm run over dep-projection trees — lexical stress classes (0/-0.5/-1) resolved by a 3-variant ensemble (all/monosyllable/none stressed), NSR with the noun-compound rule (`compound` dep), cumulative total stress, ensemble mean, per-sentence min-max norm. 1.0 = nuclear stress, NaN = punctuation. Pure numpy + iterative post-order; no constituency parser needed.
 - **Grid integration**: `line.grid_str()/grid_df()/grid_plot()` auto-fetch `tstress` when `syntax=True` — phrasal rows extend columns above the word level on each word's primary syllable (height 4 = phrasally prominent ≥0.5, height 5 = nuclear). `SyllData.word_num` bridges DF-path parse slots to the word-level values.
-- **Constraints**: `w_prom` (prominent word on weak position, `phrasal_stress >= -1`), `s_demoted` (deeply embedded word on strong position, `phrasal_stress <= -2`). Both are inert when `syntax=False` (check `has_phrasal` flag).
+- **Constraints**: `w_prom` (prominent word on weak position, `phrasal_stress >= -1`), `s_demoted` (deeply embedded word on strong position, `phrasal_stress <= -2`); gradient variants `w_stress_p`/`s_unstress_p` (pstress) and `w_stress_t`/`s_unstress_t` (tstress), thresholds per cadence (prominent > 0, weak == 0). All inert when `syntax=False` (`has_phrasal`/`has_gradient` flags).
 - **Performance**: ~1s overhead for 2155 lines (spaCy dep parse). Model loads once, cached.
 - **Config**: `DEFAULT_SYNTAX = False`, `DEFAULT_SYNTAX_MODEL = "en_core_web_sm"` in `imports.py`. spaCy is an optional dependency (`pip install prosodic[syntax]`).
 - **MaxEnt integration**: `meter.fit_annotations(data, text=text_with_syntax)` passes a pre-built syntax-enabled TextModel through to the trainer. Without this, the trainer creates its own TextModel without syntax.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,11 +34,11 @@ live smoke test, 2026-07-05). Portable, in rough order of value-per-effort:
   stress classes (cadence's own refinement). **Caveat** stands: phrasal
   constraints added zero accuracy for fixed-template verse — this is for
   prose rhythm and naturalness ranking.
-- **Phrasal variants of stress constraints** (`*_p`, `*_t`) — cadence scored
-  w/s violations against *phrasal* stress values as systematic counterparts
-  to every lexical stress constraint. v3 has only two bespoke phrasal
-  constraints (`w_prom`, `s_demoted`) thresholded on dep-tree depth.
-  Depends on the item above for the continuous values to be meaningful.
+- **Phrasal variants of stress constraints** (`*_p`, `*_t`) — ✅ shipped:
+  `w_stress_p`/`s_unstress_p` (pstress) and `w_stress_t`/`s_unstress_t`
+  (tstress), cadence-threshold semantics, inert without `syntax=True`.
+  Remaining: `w_peak_p`/`s_trough_p` need cadence's pstrength (local
+  peak/valley) feature, not yet ported.
 - **Multi-engine comparison** — never shipped in cadence (vestigial `ENGINE`
   constant); the idea survives in its `notebooks/engines.ipynb` scratch
   harness. Low priority unless a second engine (e.g. MetricalTree-proper)

--- a/methods/metrical-parsing.md
+++ b/methods/metrical-parsing.md
@@ -1,0 +1,174 @@
+# Metrical parsing in prosodic
+
+How prosodic scans a line of verse: the generative-metrics theory behind
+it, the constraint-based model, the exhaustive vectorized implementation,
+and the entity-based reference implementation. Code: `prosodic/parsing/`.
+
+## Linguistic background
+
+Generative metrics treats a scansion as a **correspondence between two
+objects**: the linguistic prominence of a line (stress, weight, word
+structure) and an abstract metrical template (alternating weak/strong
+positions). A line is metrical to the degree that the correspondence is
+good; different poets and traditions tolerate different mismatches.
+
+- **Halle & Keyser (1971)** introduced correspondence rules and the idea
+  that lines are judged by which mismatches they allow.
+- **Kiparsky (1975, 1977)** located the constraints in prosodic structure:
+  what matters is not just stress but where stresses sit inside words and
+  phrases (e.g. the special status of *lexical* stress maxima).
+- **Hanson & Kiparsky (1996)** made the theory parametric: meters choose a
+  position size (how many syllables a position may hold), a prominence
+  site, and a prominence type (stress, weight, strength). Prosodic's
+  original parser (v1, Heuser et al.) was an implementation of this
+  parametric theory, and its constraint inventory still descends from it.
+- **Optimality Theory (Prince & Smolensky 1993)** reframes such systems as
+  sets of **violable constraints**: every candidate scansion is evaluated
+  against every constraint; grammars differ in how they resolve conflicts.
+- **Harmonic Grammar** (Legendre, Miyata & Smolensky 1990) resolves
+  conflicts by **weighted sums** of violations rather than strict ranking —
+  prosodic's scoring model.
+- **Maximum-Entropy grammar** (Goldwater & Johnson 2003; Hayes & Wilson
+  2008; applied to meter by Hayes, Wilson & Shisko 2012) puts weights on a
+  probabilistic footing: candidate probability ∝ exp(−weighted violations),
+  and weights can be *learned* from data. Prosodic's `MaxEntTrainer` and
+  `meter.fit()` implement this (see below).
+
+## The model
+
+A **parse** is a segmentation of a line's syllables into an alternating
+sequence of weak/strong **positions**. With the default parameters
+(`max_s=2`, `max_w=2`), a position holds one or two syllables — a
+two-syllable position is a **resolution** (Hanson & Kiparsky's position
+size parameter): `w ws' == "when IN the.chro NI..."` etc.
+
+**Candidate generation is exhaustive**: every alternating sequence of
+positions (each `w`×n or `s`×n, n ≤ max) whose sizes sum to the line's
+syllable count. A 10-syllable line yields ~700 candidates; the counts grow
+roughly with the Fibonacci numbers, and `MAX_SYLL_IN_PARSE_UNIT` (18) caps
+the unit size (longer lines are split at phrase boundaries into lineparts
+first — see the prose-handling notes in CLAUDE.md).
+
+**Constraints** (`parsing/constraints.py`) each map a candidate to a
+violation count per position/syllable. The defaults descend from
+Kiparsky / Hanson & Kiparsky:
+
+| constraint | violated when |
+|---|---|
+| `w_stress` | stressed syllable in weak position |
+| `s_unstress` | unstressed syllable in strong position |
+| `w_peak` | lexical stress *maximum* in weak position |
+| `unres_within` | resolved (2-syll) position spans a strong or heavy syllable inside a polysyllable |
+| `unres_across` | resolved position crosses a word boundary, unless both syllables are function-word/light |
+| `foot_size` | position of 3+ syllables (inviolable in practice) |
+
+Additional constraints: `s_trough`, `clash`, `lapse`, `w_heavy`,
+`s_light`, `s_func`, `word_foot`; phrasal-stress constraints (`w_prom`,
+`s_demoted`, and the gradient `w_stress_p`/`s_unstress_p`/`w_stress_t`/
+`s_unstress_t` — see `methods/phrasal-stress.md`). Adding a constraint is
+one decorated function with a vectorized lambda.
+
+**Scoring is Harmonic Grammar**: a parse's score is the weighted sum of
+its violations (all weights 1.0 by default; settable per constraint;
+learnable by MaxEnt). Lower is better; `best_parse` is the argmin.
+
+**Harmonic bounding** (Samek-Lodovici & Prince 1999) prunes candidates
+that cannot win *under any weighting*: scansion *i* bounds scansion *j*
+iff *i*'s per-constraint violation vector is ≤ *j*'s elementwise with at
+least one strict inequality. The `unbounded` set is the Pareto frontier —
+these are the linguistically interesting readings of the line; `bounded`
+candidates are retained but flagged (visible in the web app's Line View).
+A parse with zero violations bounds everything else, which licenses a
+shortcut: perfect lines skip the O(S²) pairwise comparison entirely.
+
+## The vectorized implementation
+
+The v3 parser (`parsing/vectorized.py`) evaluates *all candidates of all
+lines at once* in numpy, without constructing entity objects:
+
+1. **Features from the DataFrame**: `TextModel` holds a flat syllable-level
+   frame (`_syll_df`); per-line feature arrays (stress, weight, strength,
+   word ids, function-word, phrasal columns) are sliced from it directly.
+2. **Scansion encoding**: for each distinct syllable count N, the candidate
+   set is encoded once as boolean matrices (S candidates × N syllables:
+   strong/weak membership, position ids, position sizes) and cached.
+3. **Batched constraint evaluation**: lines are grouped by N; features are
+   broadcast against the scansion matrices, and each constraint's
+   vectorized lambda returns an `(L, S, N)` int8 violation tensor — L
+   lines × S candidates × N syllables — in one numpy expression. (Two
+   constraints, `unres_within`/`unres_across`, still run a per-line loop;
+   lifting them is on the roadmap.)
+4. **Bounding in batch**: per-constraint violation sums `(L, S, C)` feed a
+   tiled pairwise domination kernel — on GPU via torch when available
+   (`(L, Ti, Tj, C)` difference tensors), byte-identical on numpy —
+   producing the `(L, S)` unbounded mask. Perfect-parse lines short-cut.
+5. **Lazy results**: violations, scansions, and masks are stored in a
+   `LazyParseList`; `Parse` objects are built only on access
+   (`best_parse` builds exactly one, via argmin — no sorting).
+6. **Pronunciation ambiguity**: words with multiple wordforms produce the
+   full cartesian product of per-word choices (capped at
+   `MAX_FORM_COMBOS=4096`); each combination is scored and the best
+   variant kept.
+
+Performance (Shakespeare's sonnets, 2,155 lines): 1.3 s on GPU, ~5 s CPU,
+vs ~73 s for the v2 branch-and-bound parser — because exhaustive
+evaluation of small dense tensors beats clever pruning in Python.
+`python -m prosodic.profiling` regenerates the numbers.
+
+## The entity path and the reference implementations
+
+There are two ways a line gets parsed (see "Two Parse Paths" in
+CLAUDE.md), and both use the vectorized evaluator above:
+
+- **DF path** (`text.parse()` → `parse_batch_from_df`): works entirely
+  from `_syll_df`; parse slots hold lightweight `SyllData` stand-ins.
+  Fastest; no entity objects exist at all.
+- **Entity path** (`parse_batch(text.lines, meter)`): same tensors, but
+  slots hold real `Syllable` entities with parent chains — needed when
+  downstream code walks from a syllable back to its word (HTML rendering,
+  the web app).
+
+The truly *non-vectorized* code is the *reference implementations*: every
+constraint's decorated function body is an entity-based, per-position
+formulation of the same rule (`def w_stress(mpos): ...`). These bodies do
+not run during normal parsing — only for manually constructed `Parse`
+objects — but they serve as the readable specification of each
+constraint, and the vectorized lambdas are checked against their
+semantics. If a lambda and its body ever disagree, the body is the spec.
+
+## MaxEnt weight learning
+
+`MaxEntTrainer` (`parsing/maxent.py`) learns constraint weights from
+annotated scansions or a uniform target (`meter.fit(text, "wswswswsws")`):
+log-linear model over each line's candidate set, L-BFGS-B optimization,
+vectorized gradients via einsum over same-length line groups (< 1 s on 2K
+lines). **Zones** split the violation tensor by syllable position before
+weighting (`"initial"`, integer k, or `"foot"`), letting the model learn
+positional leniency (e.g. line-initial inversion) — the learned
+`zone_weights` transfer to parsing unseen text via zone-aware scoring in
+`LazyParseList`. Because the model operates on the same `(S, N, C)`
+violation tensors the parser already produces, no parser changes are
+needed for new features.
+
+One theoretical note: overlapping constraints **stack** in HG/MaxEnt — a
+`w_peak` violation also violates `w_stress`, so its effective cost is the
+sum of both weights. This is how the model makes stress maxima in weak
+position effectively inviolable (Kiparsky) without any infinite weight.
+
+## References
+
+- Halle, M. & S. J. Keyser (1971). *English Stress: Its Form, Its Growth,
+  and Its Role in Verse*.
+- Kiparsky, P. (1975). Stress, syntax, and meter. *Language* 51.
+- Kiparsky, P. (1977). The rhythmic structure of English verse. *LI* 8.
+- Hanson, K. & P. Kiparsky (1996). A parametric theory of poetic meter.
+  *Language* 72.
+- Prince, A. & P. Smolensky (1993/2004). *Optimality Theory*.
+- Legendre, G., Y. Miyata & P. Smolensky (1990). Harmonic Grammar.
+- Samek-Lodovici, V. & A. Prince (1999). Optima. ROA-363.
+- Goldwater, S. & M. Johnson (2003). Learning OT constraint rankings using
+  a maximum entropy model.
+- Hayes, B. & C. Wilson (2008). A maximum entropy model of phonotactics.
+  *LI* 39.
+- Hayes, B., C. Wilson & A. Shisko (2012). Maxent grammars for the metrics
+  of Shakespeare and Milton. *Language* 88.

--- a/methods/phrasal-stress.md
+++ b/methods/phrasal-stress.md
@@ -1,0 +1,168 @@
+# Phrasal stress in prosodic
+
+How prosodic computes phrasal (sentence-level) prominence, where the
+algorithm comes from, and how our implementation differs from its ancestors.
+Code: `prosodic/texts/phrasal_stress.py`. Enabled with
+`TextModel(txt, syntax=True)`.
+
+## Linguistic background
+
+Lexical stress tells you which syllable of *within* is strong; it says
+nothing about whether *within* is prominent **in its sentence**. That
+second, relational kind of prominence is the subject of metrical phonology's
+founding work:
+
+- **Chomsky & Halle (1968, SPE)** formulated the **Nuclear Stress Rule
+  (NSR)**: in a phrase, primary stress falls on the rightmost stressable
+  constituent — recursively, so sentence prominence cascades down through
+  phrases. The **Compound Stress Rule (CSR)** is its mirror inside compound
+  nouns: stress the *left* member (*TIME machine*, not *time MACHINE*).
+- **Liberman & Prince (1977)** recast these rules relationally: constituents
+  are strong or weak only *relative to their sisters*, represented in binary
+  metrical trees, with the metrical **grid** as the derived rhythmic
+  representation. A word's prominence is a function of how many weak nodes
+  dominate it.
+- **Hayes (1983, 1995)** developed the grid-based side of the theory —
+  prosodic's `grid_str()` display (marks stacked over syllables by
+  prominence level) is a Hayes-style grid.
+- **Anttila and colleagues** (e.g. Anttila, Dozat, Galbraith & Shapiro
+  2020) operationalized these theories at corpus scale to study English
+  phrasal stress, rhythm in prose, and its interaction with meter — using
+  Dozat's MetricalTree tool, the direct ancestor of this module.
+
+## What Dozat's MetricalTree did
+
+[MetricalTree](https://github.com/tdozat/Metrics) (Timothy Dozat, 2015)
+computes Liberman–Prince prominence over Stanford CoreNLP parses:
+
+1. **Tree**: a constituency parse, with dependency labels decorating
+   preterminals.
+2. **Lexical stress classes**: each word is scored 0 (stressed content
+   word), −1 (unstressed function word), or −0.5 (**ambiguous**) using
+   word lists (*it*; *this/that/these/those*), PTB tag lists (CC, PRP$, TO,
+   UH, DT unstressed; MD, IN, PRP, WP$, PDT, WDT, WP, WRB ambiguous), and
+   dependency-label lists (det, expl, cc, mark unstressed; cop, neg, aux,
+   auxpass ambiguous). Punctuation and contracted clitics are NaN.
+3. **Disambiguation ensemble**: ambiguous words are resolved three
+   deterministic ways — all stressed; unstressed only if monosyllabic;
+   all unstressed — and results are averaged. This is what makes the
+   output *gradient* rather than categorical: an ambiguous monosyllable
+   ends up with fractional prominence.
+4. **NSR pass** (`set_pstress`): bottom-up through the tree; in each
+   phrase, the rightmost child with pstress 0 stays strong and every other
+   child is demoted to −1. Inside NN-sequences (compounds) the scan is
+   inverted per the CSR: the rightmost noun is provisionally weak and the
+   noun to its left is strong.
+5. **Total stress** (`set_stress`): each word's cumulative prominence =
+   its lexical stress + its preterminal pstress + the sum of pstress
+   values of every phrase dominating it — a direct arithmetization of
+   Liberman & Prince's "count the weak nodes above you."
+6. **Normalization**: per sentence, min–max normalize to [0, 1], where
+   1.0 is the sentence's nuclear stress. Two outputs per word:
+   **pstress** (preterminal phrasal stress: strong/weak within the local
+   phrase) and **tstress** (total cumulative stress: global sentence
+   prominence).
+
+[cadence](https://github.com/quadrismegistus/cadence) (archived 2026-07)
+carried this implementation forward over Stanza constituency parses, with
+one simplification: by default it substituted binary dictionary lexical
+stress for the ambiguity ensemble.
+
+## What prosodic does differently
+
+Prosodic v3 deliberately has **no constituency parser** (no Stanza, no
+torch model downloads); its `syntax=True` pipeline is spaCy
+dependency-only. The port therefore runs Dozat's algorithm over
+**head-projection trees derived from the dependency parse**: every word
+projects a phrase whose ordered children are the projections of its
+dependents plus its own preterminal.
+
+Naive projection is *not* equivalent to constituency, and the differences
+matter exactly where the NSR looks. Three topology rules (found by
+differential testing, below) restore congruence:
+
+1. **NP-internal prenominal modifiers join bare.** A dependent with no
+   dependents of its own whose relation is in {det, amod, compound,
+   nummod, predet, neg, aux, auxpass} sits in its head's phrase as a bare
+   preterminal — matching the flat Penn NP `(NP (DT the) (JJ quick)
+   (NN fox))`, so NSR demotion reaches the adjective directly.
+2. **Arguments always project**, even as single words — constituency wraps
+   them (`NP(Jack)`, `WHADVP(When)`), and that wrapper *shields* the
+   preterminal: when a subject phrase is demoted, the demotion lands on
+   the phrase node, and the word's own pstress (where the ambiguity
+   ensemble lives) survives. Notably `poss` is **not** in the bare set: a
+   possessor is an inner NP (`NP(NP(Beauty 's) rose)`), and bare-joining
+   it would wrongly trigger the compound rule (*BEAUTY'S rose*).
+3. **Noun heads with right-side complements get an inner core.** For
+   `the house that Jack built`, constituency gives
+   `NP(NP(the house) SBAR)`: the relative clause wins the NSR, but the
+   demotion hits the inner NP node and *house* keeps its preterminal
+   strength. The projection replicates this by wrapping left material +
+   head in an inner node whenever an NN-headed phrase has right
+   dependents.
+
+The compound rule needs no special handling beyond rule 1: `compound`
+dependents are typically leaves, so they sit as bare NN preterminals
+adjacent to the head noun — exactly the NN-sequence Dozat's scan expects.
+
+Everything above the tree skeleton is ported faithfully: the lexical
+stress classes, the 3-variant ensemble, the NSR/CSR scan (including its
+break/skip idiosyncrasies), cumulative total stress, and per-sentence
+min–max normalization. Output columns in `_syll_df`: `pstress`, `tstress`
+(Float64, ∈ [0,1], NaN for punctuation and for sentences with no
+variation), broadcast from words to their syllables.
+
+### Validation
+
+The port was cross-validated against cadence (Dozat's algorithm over
+Stanza constituency, ambiguity ensemble replicated) on a 9-sentence
+differential covering NSR baselines, compounds, ambiguous function words,
+relative clauses, coordination, possessives, ditransitives, and PP
+attachment (2026-07-05). Result: identical nuclear-stress placement on
+9/9; identical orderings throughout; several sentences identical to two
+decimals on every word. The differential caught two real bugs (the
+shielding asymmetry behind topology rules 1–3, and `poss` in the bare
+set) — the corrected, cross-validated values are pinned as unit tests in
+`tests/test_phrasal_gradient.py`.
+
+**One deliberate divergence**: in coordination (*dogs and cats*), Dozat's
+flat-NP scan demotes non-final conjuncts to pstress −1; prosodic keeps
+each conjunct's strength (both conjuncts carry accent in natural speech),
+while tstress still ranks the final conjunct higher, matching the
+reference ordering.
+
+**Known limitations**: (a) attachment-height differences between spaCy
+dependencies and constituency (e.g. fronted *When* sits higher as a
+WHADVP than as an `advmod` edge) shift tstress magnitudes on a few words;
+(b) whole-word possessive tokens (*Beauty's*) misparse in both spaCy and
+Stanza when pre-tokenized — an input-level limitation; (c) the lexical
+class lists are English-only.
+
+## The two value systems, and what uses them
+
+| | discrete `phrasal_stress` | gradient `pstress` / `tstress` |
+|---|---|---|
+| lineage | v3-native depth heuristic | Dozat MetricalTree port |
+| values | 0 (root) … −6, Int | [0, 1] normalized, Float |
+| computation | vectorized dep-tree depth + NSR/CSR sibling promotion | ensemble of NSR passes over projection trees |
+| constraints | `w_prom`, `s_demoted` | `w_stress_p`, `s_unstress_p`, `w_stress_t`, `s_unstress_t` (cadence thresholds: prominent > 0, weak == 0) |
+| grid | — | phrasal rows: word's primary syllable +1 level at tstress ≥ 0.5, +1 at nuclear |
+
+All phrasal constraints are inert without `syntax=True`.
+
+**Empirical caveat** (from the v3 MaxEnt experiments): on Shakespeare's
+sonnets with a fixed `wswswswsws` target, phrasal constraints added no
+accuracy over lexical stress. Phrasal prominence matters for **prose
+rhythm** and **naturalness ranking** — cadence's research agenda — not
+for fixed-template scansion.
+
+## References
+
+- Chomsky, N. & M. Halle (1968). *The Sound Pattern of English*.
+- Liberman, M. & A. Prince (1977). On stress and linguistic rhythm. *LI* 8.
+- Hayes, B. (1983). A grid-based theory of English meter. *LI* 14.
+- Hayes, B. (1995). *Metrical Stress Theory*.
+- Dozat, T. (2015). MetricalTree. github.com/tdozat/Metrics
+- Anttila, A., T. Dozat, D. Galbraith & N. Shapiro (2020). Sentence stress
+  in presidential speeches. In *Prosody in Syntactic Encoding*.
+- Heuser, R. (2021–23). cadence. github.com/quadrismegistus/cadence

--- a/prosodic/parsing/constraints.py
+++ b/prosodic/parsing/constraints.py
@@ -365,6 +365,77 @@ def s_demoted(mpos):
     return [getattr(slot.unit, 'phrasal_stress', 0) <= -2 for slot in mpos.slots]
 
 
+# --- Gradient phrasal variants (cadence's *_p / *_t constraints) ---
+# Score w/s violations against the MetricalTree gradient values (pstress =
+# within-phrase strength, tstress = cumulative sentence prominence; both
+# min-max normalized per sentence, -1 sentinel where absent). Thresholds
+# follow cadence: prominent = value > 0, unprominent = value == 0.
+# Require syntax=True; inert otherwise.
+
+def _w_stress_p_vectorized(f):
+    if not f.get("has_gradient"):
+        return np.zeros((f["L"], f["S"], f["N"]), dtype=np.int8)
+    return ((f["pstress"] > 0) & f["is_weak_pos"]).astype(np.int8)
+
+@constraint(
+    desc="No syllable of a phrasally strong word (pstress>0) on weak position",
+    scope="position",
+    vectorized=_w_stress_p_vectorized,
+)
+def w_stress_p(mpos):
+    if mpos.is_prom:
+        return [None] * len(mpos.slots)
+    return [(getattr(slot.unit, 'pstress', None) or 0) > 0 for slot in mpos.slots]
+
+
+def _s_unstress_p_vectorized(f):
+    if not f.get("has_gradient"):
+        return np.zeros((f["L"], f["S"], f["N"]), dtype=np.int8)
+    return ((f["pstress"] == 0) & f["is_strong_pos"]).astype(np.int8)
+
+@constraint(
+    desc="No syllable of a phrasally weak word (pstress==0) on strong position",
+    scope="position",
+    vectorized=_s_unstress_p_vectorized,
+)
+def s_unstress_p(mpos):
+    if not mpos.is_prom:
+        return [None] * len(mpos.slots)
+    return [getattr(slot.unit, 'pstress', None) == 0 for slot in mpos.slots]
+
+
+def _w_stress_t_vectorized(f):
+    if not f.get("has_gradient"):
+        return np.zeros((f["L"], f["S"], f["N"]), dtype=np.int8)
+    return ((f["tstress"] > 0) & f["is_weak_pos"]).astype(np.int8)
+
+@constraint(
+    desc="No syllable of a sentence-prominent word (tstress>0) on weak position",
+    scope="position",
+    vectorized=_w_stress_t_vectorized,
+)
+def w_stress_t(mpos):
+    if mpos.is_prom:
+        return [None] * len(mpos.slots)
+    return [(getattr(slot.unit, 'tstress', None) or 0) > 0 for slot in mpos.slots]
+
+
+def _s_unstress_t_vectorized(f):
+    if not f.get("has_gradient"):
+        return np.zeros((f["L"], f["S"], f["N"]), dtype=np.int8)
+    return ((f["tstress"] == 0) & f["is_strong_pos"]).astype(np.int8)
+
+@constraint(
+    desc="No syllable of a sentence-weak word (tstress==0) on strong position",
+    scope="position",
+    vectorized=_s_unstress_t_vectorized,
+)
+def s_unstress_t(mpos):
+    if not mpos.is_prom:
+        return [None] * len(mpos.slots)
+    return [getattr(slot.unit, 'tstress', None) == 0 for slot in mpos.slots]
+
+
 # === Line-scope constraints (not used in vectorized parsing) ===
 
 @constraint(desc="Ensure the parse has exactly 5 peaks", scope="line")

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -41,6 +41,15 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
         all_phrasal = syll_df['phrasal_stress'].fillna(0).values.astype(np.int32)
     else:
         all_phrasal = np.zeros(len(syll_df), dtype=np.int32)
+    # gradient phrasal stress (MetricalTree port): -1 sentinel for NaN /
+    # absent, so both `> 0` and `== 0` threshold tests stay silent there
+    has_gradient = 'tstress' in syll_df.columns and syll_df['tstress'].notna().any()
+    if has_gradient:
+        all_pstress = syll_df['pstress'].astype(float).fillna(-1.0).values.astype(np.float32)
+        all_tstress = syll_df['tstress'].astype(float).fillna(-1.0).values.astype(np.float32)
+    else:
+        all_pstress = np.full(len(syll_df), -1.0, dtype=np.float32)
+        all_tstress = np.full(len(syll_df), -1.0, dtype=np.float32)
 
     # subset arrays for non-punc rows
     np_line = all_line[non_punc_idx]
@@ -94,6 +103,8 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
             "word_ids": all_wnum[rows].astype(np.int32),
             "func_word": all_func[rows].astype(bool),
             "phrasal_stress": all_phrasal[rows].astype(np.int32),
+            "pstress": all_pstress[rows].astype(np.float32),
+            "tstress": all_tstress[rows].astype(np.float32),
         }
 
         # check if any word in this line has multiple forms
@@ -236,6 +247,8 @@ def parse_batch_from_df(syll_df, meter, line_col='line_num'):
                         "word_ids": all_wnum[rows].astype(np.int32),
                         "func_word": all_func[rows].astype(bool),
                         "phrasal_stress": all_phrasal[rows].astype(np.int32),
+            "pstress": all_pstress[rows].astype(np.float32),
+            "tstress": all_tstress[rows].astype(np.float32),
                     }
                     if wnsylls == nsylls:
                         same_feats_list.append(feats)
@@ -518,6 +531,8 @@ def extract_features(wordtokens):
         "word_ids": np.array(word_ids, dtype=np.int32),
         "func_word": np.array(func_word, dtype=bool),
         "phrasal_stress": np.zeros(n, dtype=np.int32),
+        "pstress": np.full(n, -1.0, dtype=np.float32),
+        "tstress": np.full(n, -1.0, dtype=np.float32),
     }
 
 
@@ -549,6 +564,11 @@ def _extract_features_hybrid(wordtokens, syll_df, line_num):
     phrasal = np.zeros(n, dtype=np.int32)
     if 'phrasal_stress' in line_df.columns:
         phrasal = line_df['phrasal_stress'].fillna(0).values.astype(np.int32)
+    pstress = np.full(n, -1.0, dtype=np.float32)
+    tstress = np.full(n, -1.0, dtype=np.float32)
+    if 'tstress' in line_df.columns:
+        pstress = line_df['pstress'].astype(float).fillna(-1.0).values.astype(np.float32)
+        tstress = line_df['tstress'].astype(float).fillna(-1.0).values.astype(np.float32)
 
     return {
         "sylls": sylls,
@@ -559,6 +579,8 @@ def _extract_features_hybrid(wordtokens, syll_df, line_num):
         "word_ids": line_df['word_num'].values.astype(np.int32),
         "func_word": line_df['is_functionword'].values.astype(bool),
         "phrasal_stress": phrasal,
+        "pstress": pstress,
+        "tstress": tstress,
     }
 
 
@@ -638,6 +660,9 @@ def evaluate_constraints_batch(features_list, meter_vals, position_ids, position
     func_word = np.stack([f["func_word"] for f in features_list])
     phrasal_stress = np.stack([f["phrasal_stress"] for f in features_list])
     has_phrasal = bool(np.any(phrasal_stress != 0))
+    pstress = np.stack([f.get("pstress", np.full(f["stressed"].shape, -1.0, dtype=np.float32)) for f in features_list])
+    tstress = np.stack([f.get("tstress", np.full(f["stressed"].shape, -1.0, dtype=np.float32)) for f in features_list])
+    has_gradient = bool(np.any(tstress >= 0))
 
     all_viols = np.zeros((L, S, N, C), dtype=np.int8)
 
@@ -651,6 +676,9 @@ def evaluate_constraints_batch(features_list, meter_vals, position_ids, position
         "word_ids": word_ids[:, None, :],
         "phrasal_stress": phrasal_stress[:, None, :],  # (L, 1, N)
         "has_phrasal": has_phrasal,
+        "pstress": pstress[:, None, :],       # (L, 1, N) gradient, -1 = absent
+        "tstress": tstress[:, None, :],
+        "has_gradient": has_gradient,
         "word_ids_raw": word_ids,              # (L, N) for per-line ops
         "is_strong_pos": meter_vals[None, :, :],  # (1, S, N)
         "is_weak_pos": ~meter_vals[None, :, :],

--- a/tests/test_phrasal_gradient.py
+++ b/tests/test_phrasal_gradient.py
@@ -99,6 +99,56 @@ def test_lstress_classes():
     assert ls.tolist() == [-1.0, -0.5, 0.0, -1.0]
 
 
+# Batch-2 differential regressions (cadence cross-validation, 2026-07-05).
+
+def test_ditransitive_exact():
+    # "She gave the boy a book" — exact match with cadence, every value
+    heads = np.array([1, -1, 3, 1, 5, 1], dtype=np.int32)
+    tags = np.array(['PRP', 'VBD', 'DT', 'NN', 'DT', 'NN'])
+    deps = np.array(['nsubj', 'ROOT', 'det', 'dative', 'det', 'dobj'])
+    words = np.array(['She', 'gave', 'the', 'boy', 'a', 'book'])
+    p, t = _mt_gradient(heads, words, tags, deps, np.ones(6, dtype=np.int32), 6)
+    assert np.allclose(p, [1/3, 0, 0, 1, 0, 1])
+    assert np.allclose(t, [2/9, 2/3, 0, 2/3, 1/3, 1])
+
+
+def test_pp_attachment_exact():
+    # "Time flies like an arrow" — exact match with cadence, every value
+    heads = np.array([1, -1, 1, 4, 2], dtype=np.int32)
+    tags = np.array(['NN', 'VBZ', 'IN', 'DT', 'NN'])
+    deps = np.array(['nsubj', 'ROOT', 'prep', 'det', 'pobj'])
+    words = np.array(['Time', 'flies', 'like', 'an', 'arrow'])
+    p, t = _mt_gradient(heads, words, tags, deps, np.ones(5, dtype=np.int32), 5)
+    assert np.allclose(p, [1, 0, 0, 0, 1])
+    assert np.allclose(t, [0.5, 0.5, 1/6, 0, 1])
+
+
+def test_possessive_projects_no_compound_hit():
+    # "His mother called the doctor": possessors project as inner NPs and
+    # must not trigger the compound rule (beauty's ROSE, not BEAUTY'S rose)
+    heads = np.array([1, 2, -1, 4, 2], dtype=np.int32)
+    tags = np.array(['PRP$', 'NN', 'VBD', 'DT', 'NN'])
+    deps = np.array(['poss', 'nsubj', 'ROOT', 'det', 'dobj'])
+    words = np.array(['His', 'mother', 'called', 'the', 'doctor'])
+    p, t = _mt_gradient(heads, words, tags, deps, np.ones(5, dtype=np.int32), 5)
+    assert p.tolist() == [0.0, 1.0, 0.0, 0.0, 1.0]
+    assert t[4] == 1.0  # nuclear on doctor
+
+
+def test_coordination_conjuncts_stay_strong():
+    # DELIBERATE divergence from Dozat/cadence (documented in the module):
+    # both conjuncts keep pstress strength (cadence demotes the first);
+    # tstress still orders the final conjunct above the first, matching.
+    heads = np.array([3, 0, 0, -1], dtype=np.int32)
+    tags = np.array(['NNS', 'CC', 'NNS', 'VBP'])
+    deps = np.array(['nsubj', 'cc', 'conj', 'ROOT'])
+    words = np.array(['Dogs', 'and', 'cats', 'fight'])
+    p, t = _mt_gradient(heads, words, tags, deps, np.ones(4, dtype=np.int32), 4)
+    assert p[0] == 1.0 and p[2] == 1.0   # conjuncts strong (ours)
+    assert t[2] > t[0]                   # cats > Dogs (matches cadence)
+    assert t[3] == 1.0                   # nuclear on fight
+
+
 def test_flat_sentence_normalizes_nan():
     # single word: no variation -> NaN (as in cadence)
     heads = np.array([-1], dtype=np.int32)
@@ -129,6 +179,50 @@ def test_grid_phrasal_heights():
     assert rows[2]["height"] == 1
 
 
+# ------------------------------------------------- gradient constraints
+
+def _fake_features(pstress_row, tstress_row, weak_pos_row):
+    L, S, N = 1, 1, len(pstress_row)
+    weak = np.array(weak_pos_row, dtype=bool)[None, None, :]
+    return {
+        "pstress": np.array(pstress_row, dtype=np.float32)[None, None, :],
+        "tstress": np.array(tstress_row, dtype=np.float32)[None, None, :],
+        "is_weak_pos": weak,
+        "is_strong_pos": ~weak,
+        "has_gradient": True,
+        "L": L, "S": S, "N": N,
+    }
+
+
+def test_gradient_constraint_lambdas():
+    from prosodic.parsing.constraints import (
+        _s_unstress_p_vectorized, _s_unstress_t_vectorized,
+        _w_stress_p_vectorized, _w_stress_t_vectorized,
+    )
+    # sylls:      A     B     C     D
+    # pstress:    1.0   0.0   0.5   -1(absent)
+    # position:   weak  strong weak strong
+    f = _fake_features([1.0, 0.0, 0.5, -1.0], [1.0, 0.0, 0.5, -1.0],
+                       [True, False, True, False])
+    assert _w_stress_p_vectorized(f).ravel().tolist() == [1, 0, 1, 0]
+    assert _s_unstress_p_vectorized(f).ravel().tolist() == [0, 1, 0, 0]
+    assert _w_stress_t_vectorized(f).ravel().tolist() == [1, 0, 1, 0]
+    assert _s_unstress_t_vectorized(f).ravel().tolist() == [0, 1, 0, 0]
+    # -1 sentinel (absent/NaN) never violates either polarity
+    f_off = dict(f, has_gradient=False)
+    assert _w_stress_p_vectorized(f_off).sum() == 0
+
+
+def test_gradient_constraints_inert_without_syntax():
+    t = TextModel("When in the chronicle of wasted time")
+    t.parse(constraints=('w_stress', 's_unstress', 'w_stress_t', 's_unstress_p'))
+    bp = t.lines[0].best_parse
+    assert all(
+        v == 0 for k, v in bp.viold.items()
+        if k.endswith('_t') or k.endswith('_p')
+    )
+
+
 # ------------------------------------------------- integration (needs spaCy)
 
 def _syntax_text(txt):
@@ -148,6 +242,22 @@ def test_syntax_columns():
     assert (vals == 1.0).any()  # some word carries nuclear stress
     # punctuation rows are NaN
     assert df.loc[df["is_punc"] == 1, "tstress"].isna().all()
+
+
+def test_gradient_constraints_active_with_syntax():
+    t = _syntax_text("When in the chronicle of wasted time")
+    t.parse(constraints=(
+        'w_stress', 's_unstress',
+        'w_stress_p', 's_unstress_p', 'w_stress_t', 's_unstress_t',
+    ))
+    # some parse among the candidates must incur gradient violations
+    parses = t.lines[0].parses
+    total = sum(
+        p.viold.get(c, 0)
+        for p in parses.unbounded
+        for c in ('w_stress_p', 's_unstress_p', 'w_stress_t', 's_unstress_t')
+    )
+    assert total > 0
 
 
 def test_grid_str_includes_phrasal_rows():


### PR DESCRIPTION
Completes the cadence constraint port and adds the methods write-ups.

**Constraints** — `w_stress_p`/`s_unstress_p` (pstress) and `w_stress_t`/`s_unstress_t` (tstress), cadence's threshold semantics (prominent > 0, weak == 0). Gradient features plumbed through all extraction sites with a −1 sentinel (NaN/absent never violates either polarity); fully inert without `syntax=True`. Active, they genuinely reweight parses (initial inversion on *WHEN in the CHRO…*). Not in the default constraint set — opt in via `parse(constraints=…)`, weights learnable by MaxEnt.

**Tests** — pure vectorized-lambda tests on synthetic features, inertness, an integration test (skips without spaCy), and the batch-2 differential regressions pinned from the cadence cross-validation (ditransitive + PP-attachment exact to every value; possessive no-compound-hit; the coordination divergence pinned as deliberate). Suite: 361 passed.

**Methods docs** — new `methods/` directory:
- `methods/phrasal-stress.md`: SPE→Liberman & Prince→Hayes lineage, what Dozat's MetricalTree does step by step, how our dep-projection port differs (the three topology rules and why), the 9-sentence differential validation, limitations.
- `methods/metrical-parsing.md`: Halle-Keyser→Kiparsky→Hanson & Kiparsky→OT/HG/MaxEnt lineage, the candidate/constraint/bounding model, the vectorized (L,S,N) tensor implementation, the entity path, and the non-vectorized reference implementations as constraint specs.

Both linked from CLAUDE.md; they can fold into the docs site when it's regenerated for v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)