### PR TITLE
Bounding: elite pre-screen before the exact pairwise kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ prosodic/lib/panphon/doc
 venv*
 profile_output*
 .venv
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ The parser is always vectorized and exhaustive — it evaluates ALL possible sca
 
 **Parsing flow:** `TextModel.parse()` → `parse_batch_from_df(syll_df, meter)` → groups by line, extracts features from numpy arrays → `evaluate_constraints_batch()` broadcasts features against scansion matrices → `compute_bounding_batch()` on GPU → results stored by line_num, attached to Entity lines lazily.
 
-**Bounding optimization:** Lines with a perfect parse (0 violations) skip the O(S²) pairwise comparison entirely — the perfect scansion bounds everything else.
+**Bounding optimization:** Lines with a perfect parse (0 violations) skip the O(S²) pairwise comparison entirely — the perfect scansion bounds everything else. Non-perfect lines go through an **elite pre-screen** first: candidates dominated by one of the K=16 lowest-total candidates are eliminated in O(K·S) (mean ~3 survivors of ~180 on the sonnets), and the exact pairwise kernel runs only on the survivors. Exact by transitivity of dominance — byte-identical to full pairwise (tested). CPU parse is now ≈ GPU parse; the GPU is no longer needed for parsing.
 
 ### MaxEnt Weight Learning (`parsing/maxent.py`)
 
@@ -273,13 +273,15 @@ Run `python -m prosodic.profiling` to regenerate.
 
 | Step | v2 | v3 | Speedup |
 |---|---|---|---|
-| Init (tokenize + pronunciations + entities) | 5.29s | 1.80s | 3x |
-| Parse (CPU) | 72.97s | 5.0s | 15x |
-| Parse (GPU) | 72.97s | 1.3s | 57x |
-| **End-to-end (CPU)** | **78.3s** | **6.8s** | **12x** |
-| **End-to-end (GPU)** | **78.3s** | **3.1s** | **26x** |
-| **DF-only (no entities, GPU)** | **78.3s** | **1.8s** | **42x** |
-| Syntax (dep parse) | 160.2s | 2.7s | 58x |
+| Init (tokenize + pronunciations + entities) | 5.29s | 2.1s | 3x |
+| Parse (CPU) | 72.97s | 1.9s | 38x |
+| Parse (GPU) | 72.97s | 2.2s | 33x |
+| **End-to-end (CPU)** | **78.3s** | **4.0s** | **20x** |
+| **End-to-end (GPU)** | **78.3s** | **4.3s** | **18x** |
+| **DF-only (no entities, GPU)** | **78.3s** | **3.1s** | **25x** |
+| Syntax (dep parse) | 160.2s | 2.4s | 67x |
+
+CPU now edges out GPU: the elite bounding pre-screen shrinks the exact kernel's workload below the point where GPU transfer overhead pays off.
 
 **TTS pronunciation cache**: espeak results cached to `~/prosodic_data/data/{lang}_cache.tsv`. First run phonemizes ~671 words via espeak; subsequent runs load from cache. Cold init 1.9s → warm 0.56s.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,13 +49,18 @@ live smoke test, 2026-07-05). Portable, in rough order of value-per-effort:
 
 ## Parser
 
+- ✅ **Vectorize `unres_within`/`unres_across`** — already done (commit
+  932d3df, audit sprint); the item here was stale.
+- ✅ **Bounding elite pre-screen** — candidates dominated by one of the
+  K=16 best-total candidates are eliminated in O(K·S) before the exact
+  O(S²) kernel runs on the survivors (mean ~3 of ~180 on the sonnets);
+  byte-identical by transitivity of dominance. CPU parse 9.5s → 1.9s,
+  now ≈ GPU. This also moots the former **GPU/CPU dispatch** item: the
+  exact kernel's workload is tiny either way, and the GPU is no longer
+  needed for parsing at all.
 - **Scansion prefiltering** — skip scansions where strong positions wildly
-  mismatch stressed syllables before full constraint evaluation.
-- **Vectorize `unres_within`/`unres_across`** — the last two constraints
-  still run per-line Python loops in `evaluate_constraints_batch`; liftable
-  to numpy with word-boundary masking.
-- **GPU/CPU dispatch optimization** — CPU wins for n<11 single-line, GPU for
-  n≥11 or batched; auto-dispatch by total work per nsylls group.
+  mismatch stressed syllables before full constraint evaluation. (Less
+  urgent post-screen: profile before bothering.)
 - **Lazy phoneme construction** — Syllable creates Phoneme objects eagerly;
   could defer to IPA-on-demand.
 - **Ternary meter identification** — `meter.fit()` works for binary

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -853,6 +853,68 @@ def _bound_viol_sums(v):
     return _compute_bounding_numpy(v)
 
 
+# Elite pre-screen for bounding. Most candidates are dominated by one of the
+# few lowest-total candidates; screening against the top-K first cuts the
+# exact O(S^2) pairwise kernel down to the handful of survivors (mean ~3 of
+# ~180 on the sonnets corpus). EXACT, not approximate: dominance is
+# transitive, so any dominator of a screen survivor would itself have to
+# survive the elite screen — pairwise among the survivors therefore
+# reproduces the full-set result byte-for-byte.
+BOUNDING_ELITE_K = 16
+# Pad value for ragged survivor rows: never dominates a real vector and is
+# always dominated. Must fit int16 (the torch kernel's dtype) incl. diffs.
+_BOUNDING_PAD = 8192
+
+
+def _elite_screen(viol_sums, K=BOUNDING_ELITE_K, block=512):
+    """(L, S) bool: candidate is strictly dominated by one of its line's K
+    best-total candidates. Chunked over lines to bound the (block, K, S, C)
+    difference tensor."""
+    L, S, C = viol_sums.shape
+    totals = viol_sums.sum(axis=2)
+    elite_idx = np.argpartition(totals, K - 1, axis=1)[:, :K]  # (L, K)
+    dominated = np.zeros((L, S), dtype=bool)
+    for l0 in range(0, L, block):
+        l1 = min(l0 + block, L)
+        v = viol_sums[l0:l1]
+        elite = np.take_along_axis(v, elite_idx[l0:l1, :, None], axis=1)
+        diff = elite[:, :, None, :] - v[:, None, :, :]  # (lc, K, S, C)
+        dominated[l0:l1] = ((diff <= 0).all(3) & (diff < 0).any(3)).any(1)
+    return dominated
+
+
+def _bounding_exact(viol_sums):
+    """Dispatch the exact pairwise kernel (GPU if available)."""
+    device = get_device()
+    if device is not None:
+        return _compute_bounding_batch_torch(viol_sums, device)
+    return _compute_bounding_batch_numpy(viol_sums)
+
+
+def _bounding_screened(viol_sums):
+    """Exact bounding via elite screen, then pairwise on the survivors."""
+    L, S, C = viol_sums.shape
+    if S <= 2 * BOUNDING_ELITE_K:
+        return _bounding_exact(viol_sums)
+    dominated = _elite_screen(viol_sums)
+    surv = ~dominated
+    counts = surv.sum(axis=1)
+    s_max = int(counts.max())
+    if s_max >= S:  # screen eliminated nothing; skip the gather
+        return _bounding_exact(viol_sums)
+    # gather survivors into a padded (L, s_max, C) tensor
+    order = np.argsort(~surv, axis=1, kind="stable")[:, :s_max]  # (L, s_max)
+    gathered = np.take_along_axis(
+        viol_sums.astype(np.int16, copy=False), order[:, :, None], axis=1
+    ).copy()
+    pad = np.arange(s_max)[None, :] >= counts[:, None]  # (L, s_max)
+    gathered[pad] = _BOUNDING_PAD
+    unb_small = _bounding_exact(gathered) & ~pad
+    result = np.zeros((L, S), dtype=bool)
+    np.put_along_axis(result, order, unb_small, axis=1)
+    return result
+
+
 def compute_bounding_batch(viol_sums):
     """Batch bounding for multiple lines at once.
 
@@ -875,29 +937,20 @@ def compute_bounding_batch(viol_sums):
         return totals == 0
 
     if not has_perfect.any():
-        # no shortcuts possible, full pairwise
-        device = get_device()
-        if device is not None:
-            return _compute_bounding_batch_torch(viol_sums, device)
-        return _compute_bounding_batch_numpy(viol_sums)
+        # no shortcut: elite screen + exact pairwise on the survivors
+        return _bounding_screened(viol_sums)
 
-    # mixed: shortcut some lines, full pairwise for others
+    # mixed: shortcut some lines, screened pairwise for others
     result = np.zeros((L, S), dtype=bool)
 
     # perfect lines: unbounded = score 0
     perfect_idx = np.where(has_perfect)[0]
     result[perfect_idx] = (totals[perfect_idx] == 0)
 
-    # non-perfect lines: full pairwise bounding
+    # non-perfect lines: screened pairwise bounding
     nonperfect_idx = np.where(~has_perfect)[0]
     if len(nonperfect_idx) > 0:
-        sub = viol_sums[nonperfect_idx]
-        device = get_device()
-        if device is not None:
-            sub_result = _compute_bounding_batch_torch(sub, device)
-        else:
-            sub_result = _compute_bounding_batch_numpy(sub)
-        result[nonperfect_idx] = sub_result
+        result[nonperfect_idx] = _bounding_screened(viol_sums[nonperfect_idx])
 
     return result
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -311,6 +311,16 @@ def test_bounding_tiled_equals_reference():
                 assert np.array_equal(ref, got_t), (
                     f"torch tiled != reference (shape={arr.shape}, budget={budget})")
 
+        # elite-screened path (engages when S > 2*BOUNDING_ELITE_K, falls back
+        # below that) must be byte-identical to the reference in both regimes
+        got_s = V._bounding_screened(arr.copy())
+        assert np.array_equal(ref, got_s), (
+            f"screened bounding != reference (shape={arr.shape})")
+        # and the public entry point end-to-end
+        got_e = V.compute_bounding_batch(arr.copy())
+        assert np.array_equal(ref, got_e), (
+            f"compute_bounding_batch != reference (shape={arr.shape})")
+
         # single-line entry points must agree with the batch reference too
         for li in range(arr.shape[0]):
             v_sc = arr[li]


### PR DESCRIPTION
Started as the "vectorize unres_within/unres_across" roadmap item — which turned out to be **stale** (932d3df already did it during the audit sprint). Profiling showed the real CPU cost is harmonic bounding: **8.5s of the 9.7s** sonnets parse in the O(S²) pairwise domination kernel.

**Elite pre-screen**: each line's candidates are first checked against its K=16 lowest-total candidates in O(K·S); candidates dominated by an elite are eliminated — mean **~3 survivors of ~180** per line — and the exact pairwise kernel runs only on the survivors (gathered into a padded tensor, int16-safe for the torch path).

**Exact, not approximate**: dominance is transitive, so any dominator of a screen survivor would itself survive the screen — pairwise among survivors reproduces the full-set result byte-for-byte. Verified three ways: equality against the old kernel on all 19 real workload calls from a sonnets parse; the randomized reference harness in test_parsing extended to the screened path + public entry point (duplicates, binary ties, ragged survivor counts); full suite 361 passed.

**Results** (sonnets, 2,155 lines): CPU parse **9.5s → 1.9s** (38x over v2), now faster than GPU (2.2s) — which also moots the GPU/CPU dispatch roadmap item, and means the CPU-only prosodic.app server now parses at former-GPU speed. Perf table in CLAUDE.md and ROADMAP updated (unres item marked already-done; docs agent notified to correct the same stale claim in the methods page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)