### PR TITLE
Serve docs at prosodic.app/docs (rsync from docs.yml + nginx alias)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,3 +47,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # Same artifact, second home: prosodic.app/docs (nginx alias on the
+      # VPS; see deploy/nginx-prosodic.conf). --chmod keeps everything
+      # world-readable regardless of runner umask.
+      - name: Rsync site to prosodic.app/docs
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          rsync -az --delete --chmod=Da+rx,Fa+r -e "ssh -i ~/.ssh/deploy_key" \
+            docs/_build/ "$DEPLOY_USER@$DEPLOY_HOST:/opt/prosodic/docs-site/"

--- a/deploy/nginx-prosodic.conf
+++ b/deploy/nginx-prosodic.conf
@@ -1,6 +1,15 @@
 server {
     server_name prosodic.app www.prosodic.app;
 
+    # Documentation site: rendered by GitHub Actions (docs.yml), rsynced to
+    # this path after each Pages deploy. NOTE: no try_files here — it
+    # resolves $uri against root, not alias, and 404s everything.
+    # /opt/prosodic must be o+rx so www-data can traverse into docs-site.
+    location /docs/ {
+        alias /opt/prosodic/docs-site/;
+        index index.html;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:8181;
         proxy_set_header Host $host;

--- a/deploy/nginx-prosodic.conf
+++ b/deploy/nginx-prosodic.conf
@@ -5,6 +5,8 @@ server {
     # this path after each Pages deploy. NOTE: no try_files here — it
     # resolves $uri against root, not alias, and 404s everything.
     # /opt/prosodic must be o+rx so www-data can traverse into docs-site.
+    location = /docs { return 301 /docs/; }
+
     location /docs/ {
         alias /opt/prosodic/docs-site/;
         index index.html;


### PR DESCRIPTION
Second half of the docs-publishing setup: **https://prosodic.app/docs/** now serves the same rendered artifact as GitHub Pages.

- `docs.yml` rsyncs `docs/_build/` to the VPS after each Pages deploy (existing deploy SSH secrets; `--chmod=Da+rx,Fa+r` so permissions never regress).
- `deploy/nginx-prosodic.conf` updated to match the live server config (applied + verified: all pages 200). Two gotchas documented in comments: nginx's `try_files`-inside-`alias` trap (resolves against `root` → 404s), and `/opt/prosodic` needing `o+rx` for www-data traversal (403s).
- Already done outside the repo: `gh-pages` branch deleted (Pages is fully workflow-driven), initial site content rsynced manually.

Merging this triggers docs.yml (its own path), which exercises the complete pipeline: render → Pages → rsync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)