### PR TITLE
LinePart grid methods via shared GridMethods mixin

### DIFF
--- a/prosodic/texts/lines.py
+++ b/prosodic/texts/lines.py
@@ -1,7 +1,34 @@
 from ..imports import *
 from ..words.wordtokenlist import WordTokenList
 
-class Line(WordTokenList):
+class GridMethods:
+    """Hayes-grid delegates shared by any parse-bearing unit (Line, LinePart)."""
+
+    def _grid_phrasal(self, kwargs):
+        """Auto-supply gradient phrasal prominence (syntax=True) to the grid."""
+        if 'phrasal' not in kwargs:
+            from ..analysis.grid import phrasal_values
+            kwargs['phrasal'] = phrasal_values(self.best_parse, self.text)
+        return kwargs
+
+    def grid_str(self, **kwargs) -> str:
+        """Hayes-style metrical grid of the best parse as monospace text.
+
+        With ``syntax=True`` on the text, phrasal-prominence rows extend
+        the grid above the word level (nuclear stress = tallest column).
+        """
+        return self.best_parse.grid_str(**self._grid_phrasal(kwargs))
+
+    def grid_df(self, **kwargs):
+        """Metrical grid of the best parse as a per-syllable DataFrame."""
+        return self.best_parse.grid_df(**self._grid_phrasal(kwargs))
+
+    def grid_plot(self, **kwargs):
+        """Metrical grid of the best parse as a plotnine figure."""
+        return self.best_parse.grid_plot(**self._grid_phrasal(kwargs))
+
+
+class Line(GridMethods, WordTokenList):
     """
     A class representing a line of text in a poem or prose.
 
@@ -148,29 +175,6 @@ class Line(WordTokenList):
         """
         return len(self.syllables)
 
-    def _grid_phrasal(self, kwargs):
-        """Auto-supply gradient phrasal prominence (syntax=True) to the grid."""
-        if 'phrasal' not in kwargs:
-            from ..analysis.grid import phrasal_values
-            kwargs['phrasal'] = phrasal_values(self.best_parse, self.text)
-        return kwargs
-
-    def grid_str(self, **kwargs) -> str:
-        """Hayes-style metrical grid of the best parse as monospace text.
-
-        With ``syntax=True`` on the text, phrasal-prominence rows extend
-        the grid above the word level (nuclear stress = tallest column).
-        """
-        return self.best_parse.grid_str(**self._grid_phrasal(kwargs))
-
-    def grid_df(self, **kwargs):
-        """Metrical grid of the best parse as a per-syllable DataFrame."""
-        return self.best_parse.grid_df(**self._grid_phrasal(kwargs))
-
-    def grid_plot(self, **kwargs):
-        """Metrical grid of the best parse as a plotnine figure."""
-        return self.best_parse.grid_plot(**self._grid_phrasal(kwargs))
-
     @cache
     def rime_distance(self, line: 'Line', max_dist=RHYME_MAX_DIST) -> float:
         """
@@ -248,9 +252,8 @@ class LineList(EntityList):
         """
         return self.num_rhyming > 0
 
-class LinePart(WordTokenList): 
+class LinePart(GridMethods, WordTokenList):
     prefix = 'linepart'
-    pass
 
 class LinePartList(EntityList):
     @classmethod

--- a/tests/test_phrasal_gradient.py
+++ b/tests/test_phrasal_gradient.py
@@ -315,6 +315,32 @@ def test_gradient_constraints_active_with_syntax():
     assert total > 0
 
 
+def test_linepart_grid_and_gradient_constraints():
+    # Regression for two flags from the prose-exploration work:
+    # (1) LinePart must expose the grid methods (GridMethods mixin) rather
+    #     than Entity.__getattr__ silently returning None;
+    # (2) gradient constraints must record violations on the linepart parse
+    #     path (they do — verified here so it can't silently regress).
+    t = _syntax_text(
+        "Whenever I find myself growing grim about the mouth, "
+        "I account it high time to get to sea."
+    )
+    t.parse(parse_unit='linepart',
+            constraints=('w_stress', 's_unstress', 'w_stress_t', 'w_peak_p'))
+    results = t._line_parse_results[list(t._line_parse_results)[-1]]
+    total_t = sum(
+        p.viold.get(c, 0)
+        for pl in results.values() for p in pl.unbounded
+        for c in ('w_stress_t', 'w_peak_p')
+    )
+    assert total_t > 0  # gradient constraints ACTIVE on lineparts
+    # grid methods on LinePart entities
+    t.parse()
+    lp = t.lines[0].lineparts[-1]
+    grid = lp.grid_str()
+    assert isinstance(grid, str) and grid.count("\n") >= 4
+
+
 def test_grid_str_includes_phrasal_rows():
     t = _syntax_text("When in the chronicle of wasted time\nI see descriptions of the fairest wights")
     t.parse()


### PR DESCRIPTION
Follow-up to the two library flags in #147 (prose exploration):

1. **Real bug, fixed**: `LinePart.grid_str` resolved to `None` via the `Entity.__getattr__` footgun and raised `TypeError` when called — the grid methods lived only on `Line`. Now a `GridMethods` mixin shared by `Line` and `LinePart`; prose lineparts render grids with phrasal rows (verified: nuclear *SEA* tallest in "I account it high time to get to sea").

2. **Not reproducible, pinned**: the report that gradient constraints are inert on the linepart parse path doesn't hold — both the explicit `parse_unit='linepart'` path and the long-line fallback record `w_stress_t`/`w_peak_p` violations correctly (90 `w_stress_t` across the test sentence's parse set, identical on both routes). The likely source of the misread: the per-line feats dicts carry no `has_gradient` key — the flag is computed later in `evaluate_constraints_batch`. A regression test now asserts linepart gradient violations stay nonzero so this can't silently rot either way.

Full suite: 366 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)