### PR TITLE
Ternary meter support: multi-target fit, scoring fix, corpus + tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,15 @@ The parser is always vectorized and exhaustive — it evaluates ALL possible sca
 
 - **`MaxEntTrainer(meter, regularization=100.0, zones=None)`**: zones splits the violation matrix by syllable position before training. `"initial"` = first 2 syllables vs rest. `3` = three equal zones. `"foot"` = per foot.
 - **`load_annotations(data)`**: accepts `[(text, scansion, frequency), ...]` or DataFrame with those columns. Parses all lines via `parse_batch_from_df`, matches annotations to candidate scansions.
-- **`load_text(text, "wswswswsws")`**: assigns a uniform target scansion to all lines — no annotation file needed.
+- **`load_text(text, "wswswswsws")`**: assigns a target scansion to all lines — no annotation file needed. Also accepts a LIST of targets for meters whose line length varies (ternary verse: `["wwswwswwswws", "wswwswwswws"]` = anapestic tetrameter ± iamb-initial foot); each line matches the target(s) of its syllable count.
 - **`train()`**: L-BFGS-B optimization (scipy). Converges in <1s on 2000+ lines. Vectorized gradient via `einsum` over groups of same-length lines.
 - **`learned_weights()`** / **`apply_to_meter()`**: extract or apply learned weights.
 
 **Key design**: operates on the `(S, N, C)` violation matrices already produced by the parser. Zone splitting is post-hoc feature engineering — partitions the N (syllable) axis into zones before summing, creating `C * n_zones` features. No parser changes needed.
 
-**`meter.fit()` pipeline**: `Meter.fit(text, "wswswswsws", zones=3)` trains MaxEnt weights on a corpus and stores `meter.zone_weights` (dict of zone-expanded constraint names → weights) and `meter.zones` on the meter. `LazyParseList` scoring checks for these and uses zone-aware scoring when available — splits `(S, N, C)` violations by syllable position before weighting. This means learned positional sensitivity transfers to parsing unseen text. Also `meter.fit_annotations(data)` for annotated data (list of tuples or DataFrame).
+**`meter.fit()` pipeline**: `Meter.fit(text, "wswswswsws", zones=3)` trains MaxEnt weights on a corpus and stores `meter.zone_weights` (dict of zone-expanded constraint names → weights) and `meter.zones` on the meter. `LazyParseList` scoring uses learned weights whenever `zone_weights` is set — with `zones=None` this degrades to flat weighted scoring (`zone_split` just sums over N), so `fit(zones=None)` weights are honored too. This means learned positional sensitivity transfers to parsing unseen text. Also `meter.fit_annotations(data)` for annotated data (list of tuples or DataFrame).
+
+**Ternary meters**: nothing parser-side is binary-specific — anapestic feet are `ww` positions + `s` positions, already in the candidate space (`max_w=2`). Default weights scan regular anapestic lines correctly (Byron/Browning corpus files + `tests/test_ternary.py`); `fit()` with a target list learns the ternary signature (strict `s_unstress`/`unres_within`, free `w_stress`/`unres_across` — Hanson & Kiparsky 1996). See `docs/methods/metrical-parsing.qmd` § Ternary meters.
 
 **Shared utilities**: `zone_split(viols_3d, zones)`, `zone_boundaries(zones, N)`, `make_zone_names(base_names, nsylls, zones)` — used by both MaxEntTrainer and LazyParseList.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,20 +57,16 @@ values for words with stress-ambiguous pronunciation variants).
 
 ## Parser
 
-- **Ternary meter identification** — the substantive open parser item.
-  Current state: `meter.fit()` (MaxEnt, `parsing/maxent.py`) learns weights
-  for binary iambic/trochaic targets like `"wswswswsws"`;
-  `analysis/meter_type.py` DETECTS ternary verse (fraction of `ww`
-  positions > 17.5%) but `fit()` has no ternary-aware path. Sketch:
-  (a) accept ternary target strings (`"wwswwswws"` — already expressible,
-  positions of size ≤ `max_w=2` mean a `ww` position is one unit, so the
-  target matching in `MaxEntTrainer.load_text` may already align — VERIFY
-  first, the gap may be smaller than assumed); (b) the real work is
-  probably constraint semantics: `w_peak`/`clash`/`lapse` were tuned for
-  binary alternation; test on Browning ("How They Brought the Good News",
-  anapestic) and Byron ("Destruction of Sennacherib"). Add a ternary
-  corpus file under `corpora/corppoetry_en/` first, then write the failing
-  test, then fix.
+- ✅ **Ternary meter identification** — shipped 2026-07-06. The gap was
+  indeed smaller than assumed: anapestic scansions were already in the
+  candidate space and default weights already scan Byron/Browning
+  correctly (`meter_type` → anapestic). What shipped: `load_text`/`fit()`
+  accept a LIST of targets (line-length-matched — ternary verse varies
+  line length via iamb-initial feet); fixed a real bug where
+  `fit(zones=None)` learned weights were silently ignored by
+  `LazyParseList` scoring; corpus files `en.byron.sennacherib.txt` +
+  `en.browning.goodnews.txt`; `tests/test_ternary.py` (8 tests,
+  hand-verified scansions); docs § Ternary meters.
 - **Lazy phoneme construction** — `Syllable.__init__` eagerly builds
   Phoneme children (`words/syllables.py`); could defer to IPA-on-demand
   via cached_property. Only matters on the entity path (DF path never

--- a/corpora/corppoetry_en/en.browning.goodnews.txt
+++ b/corpora/corppoetry_en/en.browning.goodnews.txt
@@ -1,0 +1,69 @@
+I sprang to the stirrup, and Joris, and he;
+I galloped, Dirck galloped, we galloped all three;
+"Good speed!" cried the watch as the gate-bolts undrew;
+"Speed!" echoed the wall to us galloping through;
+Behind shut the postern, the lights sank to rest,
+And into the midnight we galloped abreast.
+
+Not a word to each other; we kept the great pace
+Neck by neck, stride by stride, never changing our place;
+I turned in my saddle and made its girth tight,
+Then shortened each stirrup, and set the pique right,
+Rebuckled the cheek-strap, chained slacker the bit,
+Nor galloped less steadily Roland a whit.
+
+'Twas moonset at starting; but while we drew near
+Lokeren, the cocks crew and twilight dawned clear;
+At Boom, a great yellow star came out to see;
+At Düffeld, 'twas morning as plain as could be;
+And from Mecheln church-steeple we heard the half-chime,
+So Joris broke silence with, "Yet there is time!"
+
+At Aershot, up leaped of a sudden the sun,
+And against him the cattle stood black every one,
+To stare through the mist at us galloping past,
+And I saw my stout galloper Roland at last,
+With resolute shoulders, each butting away
+The haze, as some bluff river headland its spray:
+
+And his low head and crest, just one sharp ear bent back
+For my voice, and the other pricked out on his track;
+And one eye's black intelligence,—ever that glance
+O'er its white edge at me, his own master, askance!
+And the thick, heavy spume-flakes which aye and anon
+His fierce lips shook upward in galloping on.
+
+By Hasselt, Dirck groaned; and cried Joris, "Stay spur!
+Your Roos galloped bravely, the fault's not in her,
+We'll remember at Aix"—for one heard the quick wheeze
+Of her chest, saw the stretched neck and staggering knees,
+And sunk tail, and horrible heave of the flank,
+As down on her haunches she shuddered and sank.
+
+So, we were left galloping, Joris and I,
+Past Looz and past Tongres, no cloud in the sky;
+The broad sun above laughed a pitiless laugh,
+'Neath our feet broke the brittle bright stubble like chaff;
+Till over by Dalhem a dome-spire sprang white,
+And "Gallop," gasped Joris, "for Aix is in sight!"
+
+"How they'll greet us!"—and all in a moment his roan
+Rolled neck and croup over, lay dead as a stone;
+And there was my Roland to bear the whole weight
+Of the news which alone could save Aix from her fate,
+With his nostrils like pits full of blood to the brim,
+And with circles of red for his eye-sockets' rim.
+
+Then I cast loose my buff-coat, each holster let fall,
+Shook off both my jack-boots, let go belt and all,
+Stood up in the stirrup, leaned, patted his ear,
+Called my Roland his pet-name, my horse without peer;
+Clapped my hands, laughed and sang, any noise, bad or good,
+Till at length into Aix Roland galloped and stood.
+
+And all I remember is—friends flocking round
+As I sat with his head 'twixt my knees on the ground;
+And no voice but was praising this Roland of mine,
+As I poured down his throat our last measure of wine,
+Which (the burgesses voting by common consent)
+Was no more than his due who brought the good news from Ghent.

--- a/corpora/corppoetry_en/en.byron.sennacherib.txt
+++ b/corpora/corppoetry_en/en.byron.sennacherib.txt
@@ -1,0 +1,29 @@
+The Assyrian came down like a wolf on the fold,
+And his cohorts were gleaming in purple and gold;
+And the sheen of their spears was like stars on the sea,
+When the blue wave rolls nightly on deep Galilee.
+
+Like the leaves of the forest when the Summer is green,
+That host with their banners at sunset were seen:
+Like the leaves of the forest when Autumn hath blown,
+That host on the morrow lay withered and strown.
+
+For the Angel of Death spread his wings on the blast,
+And breathed in the face of the foe as he passed;
+And the eyes of the sleepers waxed deadly and chill,
+And their hearts but once heaved, and forever grew still!
+
+And there lay the steed with his nostril all wide,
+But through it there rolled not the breath of his pride:
+And the foam of his gasping lay white on the turf,
+And cold as the spray of the rock-beating surf.
+
+And there lay the rider distorted and pale,
+With the dew on his brow, and the rust on his mail,
+And the tents were all silent, the banners alone,
+The lances unlifted, the trumpet unblown.
+
+And the widows of Ashur are loud in their wail,
+And the idols are broke in the temple of Baal;
+And the might of the Gentile, unsmote by the sword,
+Hath melted like snow in the glance of the Lord!

--- a/docs/methods/metrical-parsing.qmd
+++ b/docs/methods/metrical-parsing.qmd
@@ -167,6 +167,37 @@ One theoretical note: overlapping constraints **stack** in HG/MaxEnt — a
 sum of both weights. This is how the model makes stress maxima in weak
 position effectively inviolable (Kiparsky) without any infinite weight.
 
+## Ternary meters
+
+Nothing in the parser is binary-specific: with `max_w=2`, an anapestic
+foot is simply a disyllabic weak position followed by a strong one, so
+`wws wws wws wws` is already inside the candidate space of every
+12-syllable line, and `text.meter_type` detects ternary verse from the
+frequency of `ww` positions among best parses. On Byron's "The
+Destruction of Sennacherib" and Browning's "How They Brought the Good
+News from Ghent to Aix" (both anapestic tetrameter; corpus files in
+`corpora/corppoetry_en/`), the **default** weights already scan the
+regular lines as anapests and classify both poems as ternary.
+
+Because ternary verse legitimately varies line length (an iamb-initial
+line drops one slack syllable), `meter.fit()` accepts a **list** of
+target scansions — each line matches the target(s) of its syllable
+count:
+
+```python
+meter.fit(byron, ["wwswwswwswws", "wswwswwswws"])
+```
+
+The learned weights recover Hanson & Kiparsky's (1996) characterization
+of English ternary meter as strong-position-regulated: `s_unstress`
+(every beat must be stressed) and `unres_within` (no disyllabic position
+buried inside a polysyllable) get high weights, while `w_stress` and
+`unres_across` fall to zero — stressed monosyllables sit freely in weak
+positions ("the blue **wave** rolls **night**ly"), and cross-word
+disyllabic weak positions are the norm rather than a violation. The
+mirror image of iambic pentameter, where weak positions carry the
+regulation.
+
 ## References
 
 - Halle, M. & S. J. Keyser (1971). *English Stress: Its Form, Its Growth,

--- a/prosodic/parsing/maxent.py
+++ b/prosodic/parsing/maxent.py
@@ -281,22 +281,39 @@ class MaxEntTrainer:
         self._build_line_data(results, line_texts, scansion_map)
 
     def load_text(self, text, target_scansion, lang=DEFAULT_LANG):
-        """Load a text and assign a uniform target scansion to all lines.
+        """Load a text and assign a target scansion to all lines.
 
-        Lines whose syllable count doesn't match the target scansion length
+        Lines whose syllable count doesn't match any target scansion length
         are skipped (with a warning).
 
         Args:
             text: a string, list of line strings, or TextModel.
-            target_scansion: e.g. "wswswswsws" for iambic pentameter.
+            target_scansion: a scansion string (e.g. "wswswswsws" for iambic
+                pentameter), or a list of them for meters whose line length
+                legitimately varies — e.g. ["wwswwswwswws", "wswwswwswws"]
+                for anapestic tetrameter with an optional iamb-initial foot.
+                Each line is assigned the target(s) whose length matches its
+                syllable count; two same-length targets that both match split
+                the observed frequency between them.
             lang: language code for parsing.
         """
         results, line_texts = self._parse_text(text, lang=lang)
 
-        # every line gets the same target scansion
-        scansion_map = {
-            lt: [(target_scansion, 1.0)] for lt in line_texts
-        }
+        if isinstance(target_scansion, str):
+            targets = [target_scansion]
+        else:
+            targets = [str(t) for t in target_scansion]
+
+        # each line gets the targets whose length matches one of its
+        # candidate scansions (candidates can differ in length when a word
+        # has pronunciation variants with different syllable counts)
+        scansion_map = {}
+        for i, ln in enumerate(sorted(results.keys())):
+            scans = getattr(results[ln], "_all_scansions", None) or []
+            lens = {sum(len(pos) for pos in scan) for scan in scans}
+            scansion_map[line_texts[i]] = [
+                (t, 1.0) for t in targets if len(t) in lens
+            ]
 
         self._build_line_data(results, line_texts, scansion_map)
 

--- a/prosodic/parsing/meter.py
+++ b/prosodic/parsing/meter.py
@@ -113,7 +113,11 @@ class Meter(Entity):
 
         Args:
             text: a string, list of line strings, or TextModel.
-            target_scansion: e.g. "wswswswsws" for iambic pentameter.
+            target_scansion: e.g. "wswswswsws" for iambic pentameter, or a
+                list of targets for meters whose line length varies (e.g.
+                ["wwswwswwswws", "wswwswwswws"] for anapestic tetrameter
+                with an optional iamb-initial foot) — each line uses the
+                target(s) matching its syllable count.
             zones: positional zone splitting (None, "initial", int N).
             regularization: L2 regularization strength.
             lang: language code for parsing.

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -1120,11 +1120,12 @@ class LazyParseList:
         # compute scores for ranking (weighted violation sums)
         zones = getattr(meter, 'zones', None)
         zone_weights = getattr(meter, 'zone_weights', None)
-        # when zone scoring is active, built Parse objects get their .score
-        # overridden with the zone-aware score (see _get_parse)
-        self._is_zone_scored = zones is not None and zone_weights is not None
+        # when learned weights are active, built Parse objects get their .score
+        # overridden with the learned score (see _get_parse). zones=None with
+        # learned weights = flat weighted scoring (zone_split sums over N).
+        self._is_zone_scored = bool(zone_weights)
 
-        if zones is not None and zone_weights is not None:
+        if zone_weights:
             # zone-aware scoring: split (S, N, C) -> (S, C*Z), weight with zone weights
             from .maxent import zone_split, make_zone_names
             zone_viols = zone_split(viols, zones)  # (S, C*Z)

--- a/tests/test_ternary.py
+++ b/tests/test_ternary.py
@@ -1,0 +1,151 @@
+"""Ternary (anapestic/dactylic) meter: representability, detection, MaxEnt fit.
+
+Test corpus: Byron's "The Destruction of Sennacherib" (1815), canonical
+anapestic tetrameter. Regular lines scan wws wws wws wws ("wwswwswwswws",
+12 sylls); iamb-initial variant lines scan ws wws wws wws ("wswwswwswws",
+11 sylls). Hand-verified expectations below follow the canonical scansion.
+"""
+import warnings
+
+warnings.filterwarnings("ignore")
+
+import os
+
+import pytest
+
+from prosodic.imports import *
+from prosodic.parsing.utils import get_possible_scansions
+
+CORPORA = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "corpora", "corppoetry_en",
+)
+BYRON_PATH = os.path.join(CORPORA, "en.byron.sennacherib.txt")
+BROWNING_PATH = os.path.join(CORPORA, "en.browning.goodnews.txt")
+
+# regular 12-syll line + iamb-initial 11-syll variant
+TERNARY_TARGETS = ["wwswwswwswws", "wswwswwswws"]
+
+
+@pytest.fixture(scope="module")
+def byron_txt():
+    with open(BYRON_PATH) as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
+def byron_parsed(byron_txt):
+    t = TextModel(byron_txt)
+    t.parse()
+    return t
+
+
+def _meter_strs(text):
+    """Best-parse scansions as w/s strings, one per line."""
+    out = []
+    for line in text.lines:
+        bp = line.best_parse
+        out.append(
+            "".join("s" if ch == "+" else "w" for ch in bp.meter_str)
+            if bp else ""
+        )
+    return out
+
+
+def test_ternary_scansions_representable():
+    # anapestic tetrameter fits within the default position inventory
+    # (max_w=2: each wws foot = one ww position + one s position)
+    for target in TERNARY_TARGETS:
+        scansions = get_possible_scansions(len(target))
+        joined = {"".join(scan) for scan in scansions}
+        assert target in joined
+
+
+def test_byron_meter_type_is_anapestic(byron_parsed):
+    mt = byron_parsed.meter_type
+    assert mt["foot"] == "ternary"
+    assert mt["head"] == "final"
+    assert mt["type"] == "anapestic"
+
+
+def test_byron_regular_lines_scan_anapestic(byron_parsed):
+    # hand-verified pure-anapestic lines with unambiguous lexical stress;
+    # the default weights alone should find wws wws wws wws
+    expected = {
+        "And his cohorts were gleaming in purple and gold": "wwswwswwswws",
+        "And the sheen of their spears was like stars on the sea": "wwswwswwswws",
+        "And the widows of Ashur are loud in their wail": "wwswwswwswws",
+    }
+    by_txt = {
+        line.txt.strip().rstrip(",;:.!?"): ms
+        for line, ms in zip(byron_parsed.lines, _meter_strs(byron_parsed))
+    }
+    for txt, target in expected.items():
+        assert by_txt[txt] == target, f"{txt!r} scanned {by_txt[txt]!r}"
+
+
+def test_browning_meter_type_is_anapestic():
+    # second poem, much rougher (heavy substitution): detection should
+    # still land on anapestic
+    with open(BROWNING_PATH) as f:
+        t = TextModel(f.read())
+    t.parse()
+    mt = t.meter_type
+    assert mt["foot"] == "ternary"
+    assert mt["type"] == "anapestic"
+
+
+def test_load_text_accepts_target_list(byron_txt):
+    from prosodic.parsing.maxent import MaxEntTrainer
+
+    # single uniform target only matches the 12-syll lines
+    tr1 = MaxEntTrainer(Meter(), zones=None)
+    tr1.load_text(byron_txt, TERNARY_TARGETS[0])
+    matched1 = sum(1 for ld in tr1._line_data if ld["observed"].sum() > 0)
+
+    # target list matches 11-syll iamb-initial lines too
+    tr2 = MaxEntTrainer(Meter(), zones=None)
+    tr2.load_text(byron_txt, TERNARY_TARGETS)
+    matched2 = sum(1 for ld in tr2._line_data if ld["observed"].sum() > 0)
+
+    assert matched2 > matched1
+    assert matched2 >= 18  # 22/24 on CMU; leave slack for TTS variation
+
+
+def test_fit_ternary_learns_strict_strong_positions(byron_txt):
+    # the ternary signature (Hanson & Kiparsky): strong positions must be
+    # stressed (s_unstress strict) while stressed monosyllables sit freely
+    # in weak positions (w_stress ~free)
+    meter = Meter()
+    meter.fit(byron_txt, TERNARY_TARGETS, zones=None, regularization=10.0)
+    w = meter.zone_weights
+    assert w["s_unstress"] > 1.0
+    assert w["s_unstress"] > w["w_stress"]
+    assert w["w_stress"] < 0.5
+
+
+def test_fit_zones_none_weights_are_used(byron_txt):
+    # regression: fit(zones=None) stored weights but LazyParseList only
+    # honored them when zones was non-None, silently scoring with defaults
+    from prosodic.parsing.vectorized import parse_batch_from_df
+
+    meter = Meter()
+    meter.fit(byron_txt, TERNARY_TARGETS, zones=None, regularization=10.0)
+    results = parse_batch_from_df(TextModel(byron_txt)._syll_df, meter)
+    lpl = next(iter(results.values()))
+    assert lpl._is_zone_scored
+
+
+def test_fit_ternary_improves_target_agreement(byron_txt):
+    t0 = TextModel(byron_txt)
+    t0.parse()
+    hits_default = sum(1 for ms in _meter_strs(t0) if ms in TERNARY_TARGETS)
+
+    meter = Meter()
+    meter.fit(byron_txt, TERNARY_TARGETS, zones=3, regularization=10.0)
+    t1 = TextModel(byron_txt)
+    t1.parse(meter=meter)
+    hits_fit = sum(1 for ms in _meter_strs(t1) if ms in TERNARY_TARGETS)
+
+    assert hits_fit >= hits_default
+    assert hits_fit >= 12  # 15/24 on CMU; leave slack for TTS variation


### PR DESCRIPTION
Works the "Ternary meter identification" ROADMAP item. As the ROADMAP suspected, the gap was smaller than assumed — anapestic scansions were already representable (`ww` positions, `max_w=2`) and **default weights already scan regular anapestic lines correctly** (`meter_type` correctly returns anapestic/ternary on both test poems). What was actually missing:

## Multi-target `fit()`/`load_text()`

Ternary verse legitimately varies line length (an iamb-initial line drops one slack syllable), so a single uniform target skips half the corpus (11/24 Byron lines). `target_scansion` now accepts a list, matched per line by syllable count:

```python
meter.fit(byron, ["wwswwswwswws", "wswwswwswws"])  # ± iamb-initial foot
```

## Real bug: `fit(zones=None)` weights silently ignored

`LazyParseList` only used learned weights when `zones` was non-None, so `fit(..., zones=None)` trained weights and then parsed with defaults. Learned weights now apply whenever `zone_weights` is set — `zone_split(viols, None)` already degrades to a flat weighted sum. Regression-tested.

## Results on Byron (exact-target best parses, 24 lines)

| weights | hits |
|---|---|
| default | 11 |
| fit, zones=None | 13 |
| fit, zones=3 | 15 |

Residual misses are the two 13-syllable lines (CMU's 4-syllable "Assyrian" — the poet intends trisyllabic elision) and score ties between metrically equivalent readings.

The learned weights recover Hanson & Kiparsky (1996): English ternary meter is **strong-position-regulated** — `s_unstress` (+4.3) and `unres_within` (+2.3) strict, `w_stress` and `unres_across` at zero (stressed monosyllables sit freely in weak positions; cross-word disyllabic weak positions are the norm). The mirror image of iambic pentameter. Written up in `docs/methods/metrical-parsing.qmd` § Ternary meters (prose-only page, no freeze impact).

Also adds `corpora/corppoetry_en/en.byron.sennacherib.txt` + `en.browning.goodnews.txt` (public domain, Wikisource) and `tests/test_ternary.py` (8 tests, hand-verified scansions). Full suite: 374 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
