### PR TITLE
Docs: phrasal-stress-scansion study (grid vs tree, per-meter weights)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -30,6 +30,8 @@ website:
             file: methods/phrasal-stress.qmd
           - text: "Constituency backend (experimental)"
             file: methods/constituency-backend.qmd
+          - text: "Phrasal stress & scansion (study)"
+            file: methods/phrasal-stress-scansion.qmd
           - text: "Languages"
             file: methods/languages.qmd
       # Executable worked analyses; add future pages (prose rhythm, other

--- a/docs/methods/constituency-backend.qmd
+++ b/docs/methods/constituency-backend.qmd
@@ -191,18 +191,19 @@ logic never invalidates the cache — only a pipeline-config change does.
 - The faithful grid + tree already ship as the **Line View toggle**
   (see the web app), rendering L&P's figure with real s/w edge labels.
 
-## An honest open question
+## Does the gradient earn its place? (answered)
 
-The speech validation raises a question worth stating plainly: does the
-gradient `tstress` earn its place for *any* empirical text task, or is it
-purely a theoretical construct? The evidence is mixed and cautionary — on
-Shakespeare sonnet scansion, phrasal-stress constraints added no accuracy
-over lexical stress (69.2% with or without), and here a lexical baseline
-beats the gradient on real prominence. The *categorical* structure has
-clear value (analysis, teaching, matching the literature); the *gradient's*
-empirical payoff for metrics remains unproven. That is a reason to keep the
-faithful structure and to treat the gradient as a hypothesis, not a
-settled feature.
+An earlier version of this page left open whether the gradient `tstress`
+earns its place for *any* empirical text task, or is purely theoretical. A
+follow-up MaxEnt study — [Phrasal stress & scansion](phrasal-stress-scansion.qmd)
+— answers it: **yes, tree stress does, for recovering *canonical* meter.**
+Scored against strict iambic pentameter on Shakespeare it lifts accuracy +8
+points (both engines, real learned weights), and it aids trochaic scansion
++14; it only fails to help when matching human-marked *deviations* or on
+unparseable archaic verse (Milton). That study also settles the tree-vs-grid
+question — the grid does **not** scan better than the tree (grid helps only
+in spaCy, tree in both), so keep `tstress` as the primary gradient; the
+*grid's* value stays categorical (the figure, teaching, matching L&P).
 
 ## References
 

--- a/docs/methods/phrasal-stress-scansion.qmd
+++ b/docs/methods/phrasal-stress-scansion.qmd
@@ -1,0 +1,172 @@
+---
+title: "Does phrasal stress help scansion? (and is the grid better than the tree?)"
+subtitle: "A MaxEnt study of tree stress vs grid stress as metrical constraints"
+---
+
+Prosodic exposes two L&P prominence representations — **tree stress**
+(`tstress`, cumulative eq-12) and **grid stress** (`gstress`, the RPPR grid) —
+for two engines (spaCy dependency, Stanza constituency), and offers metrical
+constraints weighting against each (`w_stress_t`/`s_unstress_t`,
+`w_stress_g`/`s_unstress_g`). Two questions follow:
+
+1. Does phrasal stress help a metrical parser choose the right scansion?
+2. If so, is L&P's *preferred* representation — the grid — actually better than
+   the cumulative tree stress?
+
+This page reports a MaxEnt study answering both. Background on the two
+representations: [Constituency backend](constituency-backend.qmd). Reproduce
+with `scripts/phrasal_scansion_eval.py`.
+
+## Method
+
+For each constraint set — **lexical** (the default constraints), **+tree**
+(`w_stress_t`, `s_unstress_t`), **+grid** (`w_stress_g`, `s_unstress_g`) — fit
+MaxEnt weights ([MaxEnt](../reference/parsing.maxent.MaxEntTrainer.qmd)) and
+measure **held-out** scansion accuracy: on a 50/50 line split, fit on one half,
+and on the other half score the model's argmax scansion against the gold.
+
+Two golds:
+
+- **Human** — the Litlab-2016 tagged sample (1736 lines, two annotators, four
+  meters: iambic 358, trochaic 368, anapestic 499, dactylic 511). Both
+  annotators enter as observed frequencies.
+- **Template** — Shakespeare's sonnets scored against *strict* iambic
+  pentameter (masculine `wswswswsws` / feminine `wswswswswsw`).
+
+::: {.callout-note title="Four confounds, handled"}
+- **Milton is excluded.** Both parsers fail on 17th-c. syntax: spaCy roots
+  *"Of Man's first disobedience… Sing…"* at the preposition **Of**; Stanza
+  labels it a **FRAG** and tags **Sing** as a proper noun. Archaic spelling
+  (`Hurld`→`NNP`) + inversion defeat both, so the phrasal stress is noise. Its
+  apparent null is uninterpretable.
+- **Sentence segmentation is correct** — prosodic splits on `.!?`, so
+  comma-ended verse lines correctly continue; the phrasal stress is computed
+  over real sentences.
+- **Positional zones don't help** — `zones=3` / `zones="initial"` slightly
+  *lower* held-out accuracy (overfit), for both engines.
+- **~3% noise floor.** `w_peak` entails `w_stress` (they co-occur), a
+  collinearity that leaves a flat ridge in the MaxEnt likelihood; L-BFGS lands
+  at slightly different lexical weights when the constraint set changes, so
+  differences below ~3 points are not meaningful.
+:::
+
+## Result 1 — the grid does not beat the tree
+
+Held-out accuracy on the human gold (overall / trochaic):
+
+```
+                spaCy                    Stanza
+              overall  trochaic       overall  trochaic
+  lexical      55.5%    39.7%          55.5%    39.7%
+  +tree        55.6%    53.6%   ✓      55.5%    53.0%   ✓
+  +grid        54.6%    51.0%          56.1%    38.4%   ✗
+```
+
+- **Tree stress robustly helps trochaic** — +14 points, both engines, above the
+  noise floor.
+- **Grid stress is engine-dependent**: it helps trochaic with spaCy (+11) but
+  not with Stanza (38.4% ≈ baseline).
+- **Overall, everything is within noise** — no representation wins on aggregate.
+
+So the grid — L&P's theoretically preferred representation — is *not* the better
+metrical signal. If anything the cumulative **tree** stress is the reliable one,
+because the grid coarsens away the content-word gradations that disambiguate a
+scansion (see [Constituency backend](constituency-backend.qmd) for the tree-vs-
+grid mechanism).
+
+## Result 2 — phrasal stress recovers *canonical* meter
+
+The trochaic effect is not a fluke of one meter. Scored against strict iambic
+pentameter on Shakespeare, phrasal **tree** stress helps substantially, with
+genuine non-zero learned weights:
+
+```
+Shakespeare sonnets, iambic pentameter (masc/fem), held-out:
+              spaCy              Stanza
+  lexical     65.0%              65.0%
+  +tree       72.5%  (+7.5)      73.1%  (+8.1)     w_stress_t 0.16 / 0.39
+  +grid       70.9%  (+5.9)      64.5%  (−0.5)     grid: engine-dependent again
+```
+
+The contrast that makes sense of everything:
+
+- **Milton** (assumed pentameter, *broken* parse): phrasal → 0 weight (noise).
+- **Tagged iambic** (*human* gold): phrasal slightly *hurts* — humans mark
+  inversions that default prominence doesn't predict.
+- **Shakespeare** (*strict template*, decent parse): phrasal *helps* (+8).
+
+Phrasal stress encodes **broad-focus default prominence**, so it helps a parser
+recover the *expected* metrical reading — but not an annotator's performed
+*deviations*, and only when the parse is good enough to compute it. That is
+exactly the "does the gradient earn its place" question from
+[Constituency backend](constituency-backend.qmd): **yes — tree stress does, for
+recovering canonical meter.**
+
+## Result 3 — per-meter weights recover the typology
+
+Fitting per meter (all phrasal constraints competing) is the most revealing cut.
+The structural weights are near-identical across engines (they don't depend on
+the parser); the phrasal weights show a clean pattern:
+
+```
+                    iambic        trochaic       anapestic      dactylic
+constraint       spaCy stanza   spaCy stanza   spaCy stanza   spaCy stanza
+─── structural (engine-independent) ────────────────────────────────────
+w_peak            1.10  0.96    1.35  1.42     0.00  0.00     0.00  0.00
+w_stress          0.61  0.84    1.18  1.33     0.00  0.00     0.00  0.00
+s_unstress        1.43  1.48    0.42  0.15     4.29  4.11     3.52  3.36
+unres_across      2.68  2.70    3.91  3.95     0.07  0.19     0.14  0.17
+unres_within      3.22  3.33    3.42  3.61     0.00  0.18     0.55  0.53
+─── phrasal ────────────────────────────────────────────────────────────
+w_stress_t        0.00  0.12    0.43  0.57     0.00  0.00     0.00  0.00
+s_unstress_t      0.00  0.74    0.00  0.04     0.36  0.81     0.24  0.92
+w_stress_g        0.02  0.00    0.00  0.00     0.00  0.00     0.00  0.00
+s_unstress_g      0.84  0.25    0.00  0.00     1.34  1.92     0.82  0.42
+```
+
+**The MaxEnt fit rediscovers binary vs ternary.** Binary meters (iambic,
+trochaic) load `w_peak`/`w_stress` (~1) *and* `unres` (~3–4) — lexical stress
+matters and resolution is forbidden. Ternary meters (anapestic, dactylic)
+collapse `w_peak`/`w_stress`/`unres` to ~0 and hang everything on `s_unstress`
+≈ 4 — weak syllables resolve freely (the `ww` runs), and the one rule is *the
+strong beats must be stressed*. This typology is identical across both engines.
+
+**The phrasal *direction* is engine-stable and meter-determined:**
+
+- **Trochaic → `w_stress`** (demote a phrasally-prominent word on a weak
+  position).
+- **Iambic, anapestic, dactylic → `s_unstress`** (a phrasally-weak word mustn't
+  sit on a strong position).
+
+It tracks the meter's head: the strong-first trochee guards the weak beat; the
+others guard the strong beats.
+
+**The phrasal *representation* (tree vs grid) is engine-dependent** — trochaic
+uses tree in both, anapestic uses grid in both, but iambic and dactylic flip
+(grid in spaCy, tree in Stanza). That is what you expect if tree and grid share
+variance (the grid is a coarsening of the tree): the fit loads whichever column
+*its own engine* computes more cleanly. So the tree-vs-grid split is engine
+artifact on a shared signal — not a meaningful preference.
+
+## Conclusions
+
+1. **Use tree stress, not the grid.** Tree stress helps in both engines; grid
+   stress helps only in spaCy. The grid — L&P's preferred representation — is
+   not empirically better for scansion.
+2. **Phrasal stress earns its place for recovering canonical meter** (strict
+   iambic +8, default trochaic +14), when the parse is decent — but not for
+   matching human-marked deviations, nor on unparseable archaic verse.
+3. **The useful signal is the phrasal *direction*** (`w_stress` vs
+   `s_unstress`), which is meter-determined and engine-stable. A principled
+   model picks one representation (tree) and lets the direction constraint do
+   the meter-specific work.
+4. **It is a refinement, not a driver.** Phrasal weights (~0.2–1.3) sit well
+   below the structural constraints (`unres` ~3, ternary `s_unstress` ~4). The
+   meter is enforced by structure and lexical stress; phrasal stress nudges the
+   ambiguous cases.
+
+## References
+
+- Liberman, M. & A. Prince (1977). On stress and linguistic rhythm. *LI* 8.
+- Hayes, B. & C. Wilson (2008). A maximum entropy model of phonotactics.
+- Litlab tagged sample: `data/tagged_samples/tagged-sample-litlab-2016.txt`.

--- a/scripts/phrasal_scansion_eval.py
+++ b/scripts/phrasal_scansion_eval.py
@@ -1,0 +1,180 @@
+"""Does phrasal stress help metrical scansion, and is the grid better than the tree?
+
+Companion to docs/methods/phrasal-stress-scansion.qmd. Fits MaxEnt constraint
+weights under three constraint sets — lexical baseline, +tree stress
+(``w_stress_t``/``s_unstress_t``), +grid stress (``w_stress_g``/``s_unstress_g``)
+— and measures held-out scansion accuracy (the model's argmax scansion matching
+the gold), for both phrasal-stress engines (spaCy dependency / Stanza
+constituency).
+
+Two golds:
+  - HUMAN: the Litlab-2016 tagged sample (data/tagged_samples/…) — 1736 lines,
+    two annotators, four meters (iambic/trochaic/anapestic/dactylic).
+  - TEMPLATE: Shakespeare's sonnets scored against strict iambic pentameter
+    (masculine ``wswswswsws`` / feminine ``wswswswswsw``).
+
+Run:  .venv/bin/python scripts/phrasal_scansion_eval.py [--engine spacy|stanza|both]
+
+Notes / caveats (see the doc): MaxEnt here has a ~3% accuracy noise floor from a
+collinearity ridge (w_peak entails w_stress); Milton is excluded because both
+parsers fail on 17th-c. syntax; sentence segmentation is correct (not a
+confound); positional zones do not help (slight overfit).
+"""
+import argparse
+import os
+import sys
+import warnings
+
+warnings.filterwarnings("ignore")
+
+import numpy as np
+import pandas as pd
+
+PATH_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TAGGED = os.path.join(PATH_REPO, "data/tagged_samples/tagged-sample-litlab-2016.txt")
+SONNETS = os.path.join(PATH_REPO, "corpora/corppoetry_en/en.shakespeare.txt")
+ENGINES = {"spacy": "en_core_web_sm", "stanza": "stanza"}
+METERS = ["iambic", "trochaic", "anapestic", "dactylic"]
+PENT = ["wswswswsws", "wswswswswsw"]  # iambic pentameter: masc + fem ending
+
+
+def _load():
+    from prosodic.imports import DEFAULT_CONSTRAINTS
+    from prosodic.parsing.meter import Meter
+    from prosodic.parsing.maxent import MaxEntTrainer
+    return list(DEFAULT_CONSTRAINTS), Meter, MaxEntTrainer
+
+
+def _tagged_df():
+    df = pd.read_csv(TAGGED, sep="\t")
+    df["ph2"] = df["parse_human2"].astype(str).str.replace("|", "", regex=False)
+    df["line"] = df["line"].astype(str).str.strip()
+    return df
+
+
+def _annotations(df):
+    """Both annotators as observed frequencies: (line, scansion, 1) rows."""
+    rows = []
+    for _, r in df.iterrows():
+        for col in ("parse", "ph2"):
+            s = str(r[col]).strip()
+            if s and set(s) <= set("ws"):
+                rows.append((r["line"], s, 1))
+    return pd.DataFrame(rows, columns=["text", "scansion", "frequency"])
+
+
+def _syntax_text(lines, model):
+    import prosodic
+    return prosodic.Text("\n".join(lines), syntax=True, syntax_model=model)
+
+
+def _accuracy(trainer, by=None):
+    """argmax(predicted) == argmax(observed), overall or grouped by ``by``
+    (dict line->group)."""
+    from collections import defaultdict
+    cor, tot = defaultdict(int), defaultdict(int)
+    for ld in trainer._line_data:
+        if ld["observed"].sum() == 0:
+            continue
+        g = by.get(ld["text"].strip(), "?") if by else "all"
+        tot[g] += 1
+        p = trainer._softmax_probs(ld["viols"], trainer._weights)
+        if int(np.argmax(p)) == int(np.argmax(ld["observed"])):
+            cor[g] += 1
+    return {g: (cor[g], tot[g]) for g in tot}
+
+
+def _held_out(cons, data, stext, meter_by_line, MaxEntTrainer, Meter, zones=None):
+    lines = list(dict.fromkeys(data["text"]))
+    train = set(lines[0::2])
+    tr_d = data[data.text.isin(train)]
+    te_d = data[~data.text.isin(train)]
+    tr = MaxEntTrainer(Meter(constraints=cons), zones=zones)
+    tr.load_annotations(tr_d, text=stext)
+    tr.train()
+    te = MaxEntTrainer(Meter(constraints=cons), zones=zones)
+    te.load_annotations(te_d, text=stext)
+    te._weights, te.zones = tr._weights, tr.zones
+    return _accuracy(te, by=meter_by_line), tr.learned_weights()
+
+
+def run_grid_vs_tree(DEF, Meter, MaxEntTrainer, engines):
+    """Held-out accuracy: lexical / +tree / +grid, per engine (tagged human gold)."""
+    df = _tagged_df()
+    data = _annotations(df)
+    lines = list(dict.fromkeys(df["line"]))
+    meter_by_line = dict(zip(df["line"], df["Meter Scheme"]))
+    conds = {
+        "lexical": DEF,
+        "+tree": DEF + ["w_stress_t", "s_unstress_t"],
+        "+grid": DEF + ["w_stress_g", "s_unstress_g"],
+    }
+    print("\n### Grid vs tree — held-out accuracy on human gold (overall / trochaic)\n")
+    for eng, model in engines.items():
+        stext = _syntax_text(lines, model)
+        print(f"  {eng}:")
+        for name, cons in conds.items():
+            acc, _ = _held_out(cons, data, stext, meter_by_line, MaxEntTrainer, Meter)
+            tc = sum(c for c, _ in acc.values())
+            tt = sum(t for _, t in acc.values())
+            tro = acc.get("trochaic", (0, 1))
+            print(f"    {name:8} overall {tc/tt:5.1%}   trochaic {tro[0]/max(tro[1],1):5.1%}")
+
+
+def run_shakespeare(DEF, Meter, MaxEntTrainer, engines, n=1500):
+    """Held-out accuracy on the sonnets vs strict iambic pentameter."""
+    lines = list(dict.fromkeys(
+        l.strip() for l in open(SONNETS) if l.strip()))[:n]
+    data = pd.DataFrame([(ln, t, 1) for ln in lines for t in PENT],
+                        columns=["text", "scansion", "frequency"])
+    print("\n### Shakespeare sonnets vs strict iambic pentameter — held-out\n")
+    for eng, model in engines.items():
+        stext = _syntax_text(lines, model)
+        print(f"  {eng}:")
+        for name, cons in {"lexical": DEF,
+                           "+tree": DEF + ["w_stress_t", "s_unstress_t"],
+                           "+grid": DEF + ["w_stress_g", "s_unstress_g"]}.items():
+            acc, w = _held_out(cons, data, stext, None, MaxEntTrainer, Meter)
+            c, t = acc.get("all", (0, 1))
+            ph = {k: round(v, 2) for k, v in w.items() if k.endswith(("_t", "_g"))}
+            print(f"    {name:8} {c/t:5.1%}   phrasal {ph}")
+
+
+def run_per_meter_weights(DEF, Meter, MaxEntTrainer, engines):
+    """Full learned weights per meter (DEF + tree + grid), per engine."""
+    df = _tagged_df()
+    lines = list(dict.fromkeys(df["line"]))
+    cons = DEF + ["w_stress_t", "s_unstress_t", "w_stress_g", "s_unstress_g"]
+    print("\n### Learned weights per meter (DEF + tree + grid phrasal)\n")
+    for eng, model in engines.items():
+        stext = _syntax_text(lines, model)
+        W = {}
+        for mtr in METERS:
+            data = _annotations(df[df["Meter Scheme"] == mtr])
+            tr = MaxEntTrainer(Meter(constraints=cons))
+            tr.load_annotations(data, text=stext)
+            tr.train()
+            W[mtr] = tr.learned_weights()
+        print(f"  {eng}:")
+        print("    " + f"{'constraint':16}" + "".join(f"{m:>11}" for m in METERS))
+        for c in cons:
+            print("    " + f"{c:16}" + "".join(f"{round(W[m].get(c, 0), 2):>11}" for m in METERS))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", choices=["spacy", "stanza", "both"], default="both")
+    ap.add_argument("--only", choices=["grid", "shakespeare", "weights"], default=None)
+    args = ap.parse_args()
+    engines = ENGINES if args.engine == "both" else {args.engine: ENGINES[args.engine]}
+    DEF, Meter, MaxEntTrainer = _load()
+    if args.only in (None, "grid"):
+        run_grid_vs_tree(DEF, Meter, MaxEntTrainer, engines)
+    if args.only in (None, "shakespeare"):
+        run_shakespeare(DEF, Meter, MaxEntTrainer, engines)
+    if args.only in (None, "weights"):
+        run_per_meter_weights(DEF, Meter, MaxEntTrainer, engines)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Phrasal stress & scansion — a MaxEnt study

Writes up the empirical investigation into whether phrasal stress helps metrical scansion and whether L&P's grid representation beats the cumulative tree stress. Adds a methods page (`docs/methods/phrasal-stress-scansion.qmd`) and a reproducible script (`scripts/phrasal_scansion_eval.py`). No library code changes.

### Findings

1. **The grid does not scan better than the tree.** Tree stress helps in both engines; grid stress helps only in spaCy (0 weight in Stanza). Keep `tstress` as the primary gradient — the grid's value stays categorical (figure, teaching, matching L&P).
2. **Phrasal (tree) stress earns its place for recovering *canonical* meter** — strict iambic pentameter on Shakespeare **+8 pts** (both engines, genuine non-zero weights), default trochaic **+14**. It does *not* help when matching human-marked deviations, nor on unparseable archaic verse (**Milton excluded** — both spaCy and Stanza fail on 17th-c. syntax).
3. **Per-meter weights recover the binary/ternary typology**; the phrasal **direction** (`w_stress` vs `s_unstress`) is meter-determined and engine-stable, while the tree-vs-grid **representation** is engine artifact on a shared signal.

Confounds handled and documented: sentence segmentation is correct (not a confound), positional zones overfit, and a ~3% accuracy noise floor from the `w_peak`/`w_stress` collinearity ridge. Answers the "does the gradient earn its place" open question in the constituency-backend methods page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
