### PR TITLE
Remote Stanza: install on server + graceful 400 when missing

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -52,6 +52,13 @@ jobs:
             sudo -u prosodic git reset --hard origin/master
             sudo -u prosodic git clean -fd prosodic/web/static_build
             sudo -u prosodic /opt/prosodic/.venv/bin/pip install -e . --quiet
+            # Faithful L&P / Stanza backend — best-effort so a failure here
+            # (torch build, model download, disk) never breaks the deploy:
+            # spaCy stays the default and syntax_model=stanza degrades to a
+            # clean 400. Model download is idempotent (skips if already present).
+            sudo -u prosodic /opt/prosodic/.venv/bin/pip install 'stanza>=1.5' 'hashstash[best]' --quiet || echo "WARN: Stanza deps install failed — faithful backend will be unavailable"
+            sudo -u prosodic /opt/prosodic/.venv/bin/python -c "import stanza; stanza.download('en')" || echo "WARN: Stanza model download failed"
+            sudo -u prosodic /opt/prosodic/.venv/bin/python -c "from prosodic.analysis.metrical_lp import _get_stanza; _get_stanza()" || echo "WARN: Stanza pipeline warmup failed"
             cd prosodic/web/frontend
             sudo -u prosodic npm ci --no-audit --no-fund --silent
             sudo -u prosodic npm run build

--- a/prosodic/analysis/metrical_lp.py
+++ b/prosodic/analysis/metrical_lp.py
@@ -255,11 +255,28 @@ def figure_montana_cowboy() -> LPTree:
 _NLP_CACHE: dict = {}
 
 
+def _require_stanza():
+    """Import Stanza, or raise a clear, actionable error. The faithful L&P
+    backend is opt-in (Stanza is a heavy dependency), so a plain
+    ModuleNotFoundError would surface as an opaque 500 in the web app."""
+    try:
+        import stanza
+        return stanza
+    except ImportError as e:
+        raise ImportError(
+            "The faithful L&P constituency backend (syntax_model='stanza', "
+            "parse_lptree, /api/parse/lp) requires Stanza, which is not "
+            "installed. Install with: pip install 'prosodic[constituency]' "
+            "— this pulls stanza; the constituency model downloads "
+            "automatically on first use."
+        ) from e
+
+
 def _get_stanza(lang: str = "en"):
     """Lazily build/cache a Stanza constituency pipeline."""
     if lang not in _NLP_CACHE:
         import warnings
-        import stanza
+        stanza = _require_stanza()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             _NLP_CACHE[lang] = stanza.Pipeline(
@@ -316,7 +333,7 @@ def _stanza_parse(texts, lang: str = "en"):
     Caching the raw parse (not our L&P trees) means Stanza's expensive
     constituency parse is paid once per unique text ever, while all the
     prosodic-side tree/grid/stress logic still runs fresh on top."""
-    import stanza
+    stanza = _require_stanza()
     stash = _get_stanza_stash()
     out = [None] * len(texts)
     todo = []

--- a/prosodic/web/api.py
+++ b/prosodic/web/api.py
@@ -27,6 +27,14 @@ import threading
 app = FastAPI(title="Prosodic", description="Metrical parser for English and Finnish")
 
 
+@app.exception_handler(ImportError)
+async def _missing_backend_handler(request, exc):
+    """An optional backend (e.g. Stanza for syntax_model='stanza') isn't
+    installed — return a clean, actionable 400 instead of an opaque 500."""
+    from fastapi.responses import JSONResponse
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
 @app.middleware("http")
 async def _security_headers(request: Request, call_next):
     """Add conservative security headers to every response.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -438,3 +438,23 @@ def test_browser_homepage(page, app_server):
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+def test_stanza_missing_returns_clean_400(client, monkeypatch):
+    # syntax_model='stanza' without Stanza installed must degrade to a clean
+    # 400 (actionable message), not an opaque 500. The stanza path needs no
+    # spaCy, so this runs even where spaCy is absent.
+    import prosodic.analysis.metrical_lp as M
+
+    def _boom():
+        raise ImportError("Stanza not installed. Install with: "
+                          "pip install 'prosodic[constituency]'")
+
+    monkeypatch.setattr(M, "_require_stanza", _boom)
+    monkeypatch.setattr(M, "_NLP_CACHE", {})
+    monkeypatch.setattr(M, "_STANZA_STASH", None)
+    resp = client.post('/api/parse', json=_default_parse_data(
+        text='an uncached distinctive phrase for the stanza guard test',
+        syntax=True, syntax_model='stanza'))
+    assert resp.status_code == 400
+    assert 'stanza' in resp.json()['detail'].lower()


### PR DESCRIPTION
## Remote Stanza: install on the server (A) + graceful 400 when missing (B)

Stanza wasn't installed on prosodic.app, so the faithful L&P backend was unavailable there and `syntax_model="stanza"` returned an opaque **500**.

**(A) Install Stanza on the server.** The `stable-release.yml` deploy now installs the Stanza backend (`stanza` + `hashstash[best]`) and downloads/warms the constituency model — all **best-effort** (`|| echo`), so a torch build / model download / disk failure can never break the deploy. spaCy stays the default; if Stanza setup fails it simply stays unavailable.

**(B) Graceful degradation.** A missing Stanza no longer 500s:
- `_require_stanza()` raises one clear, actionable `ImportError` at the single choke point (`_get_stanza` / `_stanza_parse`).
- A FastAPI `ImportError` handler turns it into a clean **400** with the install hint (`pip install 'prosodic[constituency]'`).

Verified: `syntax_model="stanza"` returns **400** (not 500) when Stanza is absent, 200 when present; the `/api/parse/lp` toggle was already graceful. New regression test; full suite green (437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
