### PR TITLE
Fix function-word stress: ambiguous-stress must win over unstressed

### DIFF
--- a/prosodic/langs/langs.py
+++ b/prosodic/langs/langs.py
@@ -198,10 +198,19 @@ class LanguageModel:
         token = token.lower()
         meta = {}
 
-        if force_unstress is None and token in self.unstressed_words:
-            force_unstress = True
-        elif force_ambig_stress is None and token in self.ambig_stressed_words:
+        # Ambiguous-stress wins over unstressed when a word is in BOTH lists.
+        # Every personal pronoun (she, we, they, them, he, it, you, his, ...)
+        # is listed in ambig_stress_words.txt AND unstressed_words.txt: the
+        # ambig entry means "can bear a metrical beat," the unstressed entry
+        # means "reduces phrasally." Checking unstressed first collapsed those
+        # pronouns to a single unstressed form, so they could never fill a
+        # strong metrical position without an s_unstress violation — inflating
+        # metrical tension (esp. in prose). Prosodic v1 (lib/Dictionary.py
+        # maybeUnstress) checked maybe-stressed FIRST; this restores that.
+        if force_ambig_stress is None and token in self.ambig_stressed_words:
             force_ambig_stress = True
+        elif force_unstress is None and token in self.unstressed_words:
+            force_unstress = True
 
         ## try dictionary (includes user cache)
         sylls_ipa_ll = self.get_sylls_ipa_ll_dict(token)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,6 +7,27 @@ from pandas.testing import assert_frame_equal
 
 disable_caching()
 
+def test_pronoun_stress_promotion():
+    # Personal pronouns are listed in BOTH ambig_stress_words.txt and
+    # unstressed_words.txt. ambiguous-stress must win, so they keep a stressed
+    # variant and can fill a strong metrical position without an s_unstress
+    # violation. Regression: v3 once checked unstressed first, collapsing them
+    # to a single unstressed form and inflating metrical tension (esp. in prose;
+    # -0.21 mean best-parse viols on the Shakespeare sonnets when fixed).
+    from prosodic.langs.english import EnglishLanguage
+    lang = EnglishLanguage()
+    for w in ("she", "we", "they", "them", "he", "you", "his", "her"):
+        forms, _ = lang.get_sylls_ipa_ll(w)
+        assert len(forms) == 2, f"{w!r} should have stressed+unstressed forms, got {forms}"
+    # words only in unstressed_words must NOT over-promote (stay 1 form)
+    for w in ("the", "a", "of"):
+        forms, _ = lang.get_sylls_ipa_ll(w)
+        assert len(forms) == 1, f"{w!r} should stay a single unstressed form, got {forms}"
+    # end-to-end: pronouns in strong slots promote instead of all violating
+    bp = TextModel("as we discovered them when we escaped").line1.best_parse
+    assert bp.num_viols <= 1, (bp.meter_str, bp.num_viols)
+
+
 def test_feet():
     # iambic test
     tstr = "embrace " * 5


### PR DESCRIPTION
## The bug
`LanguageModel.get_sylls_ipa_ll` checked `unstressed_words` **before** `ambig_stress_words`:

```python
if   token in self.unstressed_words:   force_unstress = True
elif token in self.ambig_stressed_words: force_ambig_stress = True
```

Every personal pronoun — `she, we, they, them, he, it, you, his, her, him, me, i, thee, thou, thy, their, …` (20 words) — is in **both** lists. The `ambig` entry means "can bear a metrical beat"; the `unstressed` entry means "reduces phrasally." Checking `unstressed` first collapsed these pronouns to a **single unstressed form**, so a pronoun in a strong metrical position always incurred an `s_unstress` violation it couldn't escape — systematically inflating metrical tension, worst in prose (most pronouns).

## Root cause
Prosodic **v1** (`lib/Dictionary.py::maybeUnstress`, Dec 2020) checked **maybe-stressed first** (`if maybestressed … elif unstressed`). The v3 rewrite flipped the precedence. This restores v1's order.

The fix is targeted — words in only one list are unaffected; only dual-listed words (the pronouns) regain their stressed variant. `the`/`a`/`of` stay single unstressed forms.

## Effect on the Shakespeare sonnets (2155 lines)
| | before | after |
|---|---|---|
| mean best-parse violations | 1.2251 | **1.0135** (−0.21) |
| lines improved / worsened | — | **428 / 0** |
| best meter changed | — | 191 |

0 lines get worse — adding a pronunciation variant can only expand the candidate set, so the parser finds equal-or-better parses. Giving pronouns their stressed variant back tightens the scansion of canonical iambic pentameter.

## Test
`test_pronoun_stress_promotion`: dual-listed pronouns → 2 forms; `the`/`a`/`of` stay 1 form; a pronoun-heavy line no longer over-violates. Full suite: **438 passed**.

Independent of #163. (Surfaced while re-parsing a corpus with current prosodic and comparing to the v1-generated 2020 data.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)