### PR TITLE
Fix is_heavy: long monophthongs (iː, uː, …) are heavy

### DIFF
--- a/prosodic/texts/syll_df.py
+++ b/prosodic/texts/syll_df.py
@@ -19,21 +19,30 @@ def _phone_is_vowel(phone_txt):
     return cons < 1
 
 
+def _phone_is_long(phone_txt):
+    """A long vowel (iː, uː, ɔː, ...) per panphon's `long` feature."""
+    return get_phoneme_feats(phone_txt).get('long', -1) == 1
+
+
 def _syll_is_heavy_from_ipa(ipa):
     """Compute is_heavy from IPA string without constructing Entity objects.
 
-    Heavy = has consonant ending OR has diphthong (>1 vowel).
+    Heavy = a branching rime: a coda (consonant ending) OR a long/complex
+    nucleus. A long/complex nucleus is a diphthong (>1 vowel) OR a long
+    monophthong (iː/uː/...). Long monophthongs were previously missed (only
+    coda + diphthong counted), so e.g. "see"/"too" were scored light.
     """
     phones = _parse_ipa_cached(ipa)
     if not phones:
         return False
-    # consonant ending
-    last_is_cons = not _phone_is_vowel(phones[-1])
-    if last_is_cons:
+    # coda (consonant ending)
+    if not _phone_is_vowel(phones[-1]):
         return True
-    # diphthong
-    num_vowels = sum(1 for p in phones if _phone_is_vowel(p))
-    return num_vowels > 1
+    # long/complex nucleus: diphthong (>1 vowel) or a long monophthong
+    vowels = [p for p in phones if _phone_is_vowel(p)]
+    if len(vowels) > 1:
+        return True
+    return any(_phone_is_long(p) for p in vowels)
 
 
 def build_syll_df(token_dicts, lang=DEFAULT_LANG):

--- a/prosodic/words/syllables.py
+++ b/prosodic/words/syllables.py
@@ -139,6 +139,17 @@ class Syllable(Entity):
         return self.num_vowels > 1
 
     @property
+    def has_long_vowel(self) -> bool:
+        """
+        Check if the syllable contains a long monophthong (iː, uː, ...).
+
+        Returns:
+            True if any vowel phoneme carries panphon's `long` feature.
+        """
+        return any(p.is_vowel and p.feats.get("long", -1) == 1
+                   for p in self.children)
+
+    @property
     def is_stressed(self) -> bool:
         """
         Check if the syllable is stressed.
@@ -153,10 +164,15 @@ class Syllable(Entity):
         """
         Check if the syllable is heavy.
 
+        Heavy = branching rime: a coda, OR a long/complex nucleus (diphthong
+        or long monophthong). Long monophthongs (iː/uː/...) were previously
+        missed, mis-scoring e.g. "see"/"too" as light.
+
         Returns:
             True if the syllable is heavy, False otherwise.
         """
-        return bool(self.has_consonant_ending or self.has_dipthong)
+        return bool(self.has_consonant_ending or self.has_dipthong
+                    or self.has_long_vowel)
 
     @property
     def is_strong(self) -> Optional[bool]:

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -240,6 +240,29 @@ class TestParsedDf:
         assert 'is_best' in pdf.columns
         assert 'is_bounded' in pdf.columns
 
+    def test_syllable_weight_long_and_complex_nuclei(self):
+        # Heavy = coda OR long/complex nucleus (diphthong OR long monophthong).
+        # Regression: long monophthongs (siː, tuː, ...) were scored light
+        # because only coda + diphthong were counted (#is-heavy-long-vowel).
+        from prosodic.texts.syll_df import _syll_is_heavy_from_ipa
+        heavy = ["siː", "tuː", "sɔː", "biː",      # long monophthongs
+                 "greɪ", "goʊ", "maɪ", "naʊ",       # diphthongs
+                 "kæt", "sɪt"]                       # codas
+        light = ["ðə", "mɑ"]                         # short open
+        for ipa in heavy:
+            assert _syll_is_heavy_from_ipa(ipa), f"{ipa} should be heavy"
+        for ipa in light:
+            assert not _syll_is_heavy_from_ipa(ipa), f"{ipa} should be light"
+        # DF path and Entity path must agree on real words
+        for w in ("see", "too", "gray", "cat", "the", "greater"):
+            t = TextModel(w)
+            df_heavy = [bool(x) for x in t._syll_df[t._syll_df.form_idx == 0].is_heavy]
+            wt = t.wordtokens[0]
+            ent_heavy = [s.is_heavy for s in wt.children[0].children[0].children]
+            assert df_heavy == ent_heavy, (w, df_heavy, ent_heavy)
+        # "see" is a single long-vowel syllable -> heavy in both paths
+        assert TextModel("see")._syll_df.iloc[0].is_heavy
+
     def test_parsed_df_join_keys(self):
         t = TextModel("From fairest creatures we desire increase")
         pdf = t.parsed_df


### PR DESCRIPTION
## The bug
`is_heavy` counted a syllable heavy only if it had a **coda** or a **diphthong** (`num_vowels > 1`). It missed **long monophthongs** — `see` /siː/, `too` /tuː/, `saw` /sɔː/, `bee` /biː/ were scored **light**. A branching rime is heavy whether the nucleus branches via a diphthong *or* a long vowel (two moras either way).

This mis-scores anything reading `is_heavy`: the resolution constraints `unres_within`/`unres_across` (condition: "1st syllable **light** and stressed"), and `w_heavy`/`s_light`.

## Fix
Both weight paths now also count a long monophthong via panphon's `long` feature, kept consistent:
- DF path: `_syll_is_heavy_from_ipa` (`texts/syll_df.py`)
- Entity path: `Syllable.is_heavy` (`words/syllables.py`, new `has_long_vowel`)

Verified the two paths agree per syllable.

## Impact
Shakespeare sonnets, mean best-parse violations: **1.0135 to 1.0139** — negligible, because it affects *resolution* (the unbounded tail of resolved scansions), not the unresolved iambic-pentameter winner. Full suite: **439 passed**.

## How it was found
Cross-version comparison (a `cmp_prosodics` harness running the same line through prosodic v1.3.8 / v2.1.2 / v3.6.0): on `greater`, v1 scored the first syllable light and v3 heavy. It turned out v1 honored vowel length but not diphthongs; v3 honored diphthongs but not vowel length — each `is_heavy` rule was half-complete. This makes v3 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
