### PR TITLE
Fix trailing-apostrophe word lookup (that'/augustus' fell to espeak)

### DIFF
--- a/prosodic/langs/langs.py
+++ b/prosodic/langs/langs.py
@@ -202,7 +202,16 @@ class LanguageModel:
 
     @cache(maxsize=None)
     def get_sylls_ipa_ll(self, token, force_unstress=None, force_ambig_stress=None):
-        token = token.lower()
+        # Strip a BARE trailing apostrophe from the lookup key. The tokenizer
+        # regex ([\w']+) glues the ASCII apostrophe onto a word, so a dangling
+        # possessive/quote mark survives ("that'", "augustus'") and misses the
+        # CMU dict + function-word lists, forcing an often-mis-stressed espeak
+        # fallback (augustus' -> AU-gus-tus, not a-GUS-tus; that' -> only the
+        # stressed form). A trailing apostrophe is never "apostrophe+letter", so
+        # dropping it is safe: don't/'twas (no trailing ') are untouched, and
+        # boys' -> boys yields the same pronunciation. This is the single choke
+        # point for all three lookups below and both parse paths.
+        token = token.lower().rstrip("'’")
         meta = {}
 
         # Ambiguous-stress wins over unstressed when a word is in BOTH lists.


### PR DESCRIPTION
The tokenizer regex `[\w']+` glues the ASCII apostrophe onto a word, and the pronunciation lookup key (`get_sylls_ipa_ll`) only lowercased — never stripped punctuation. So a **bare trailing apostrophe** survived (`that'`, `augustus'`, possessive plurals) and missed the CMU dict + function-word lists, forcing an often-mis-stressed espeak fallback:

- `augustus'` → **AU**-gus-tus (espeak) instead of dict a-**GUS**-tus
- `that'` → only the stressed form, losing the reduced function-word variant

**Fix:** strip a trailing apostrophe from the lookup key (`token.lower().rstrip("'’")`) at the single choke point feeding all three lookups (function-word, dict, espeak) and both parse paths. A trailing apostrophe is never apostrophe+letter, so it's safe — `don't`/`'twas` unchanged, `boys'`→`boys` same pronunciation, `that'`→both forms, `augustus'`→a-GUS-tus. 442 tests pass.

Surfaced by the antimetricality reparse (a residual v1↔v3 divergence). **Separate latent issue, noted not fixed:** the tokenizer drops the *curly* apostrophe (U+2019) entirely, so `it's`(curly) → `it` + `s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)