### PR TITLE
Lazy entity access: entity-free rendering on the DF path

### DIFF
--- a/prosodic/parsing/parses.py
+++ b/prosodic/parsing/parses.py
@@ -864,9 +864,15 @@ class Parse(Entity):
         Returns:
             Dict[str, List[ParseSlot]]: Dictionary mapping word tokens to parse slots.
         """
+        # Key by the tokenizer's word number, which BOTH paths carry: the entity
+        # path via slot.unit.wordtoken.num, the DF path via SyllData.word_num (no
+        # parent chain). So this works on a DF-path parse without building
+        # entities — callers look up by WordToken.num (same counter).
         wordtokend = defaultdict(list)
         for slot in self.slots:
-            wordtokend[slot.unit.wordtoken.key].append(slot)
+            wt = getattr(slot.unit, 'wordtoken', None)
+            key = wt.num if wt is not None else getattr(slot.unit, 'word_num', None)
+            wordtokend[key].append(slot)
         return wordtokend
 
     def stats_d(self, norm: Optional[bool] = None) -> Dict[str, Any]:

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -1742,7 +1742,7 @@ class LazyParseList:
         from .parselists import ParseList
         return ParseList(self.data, parse_unit=self.parse_unit, parent=self.parent).get_df(**kwargs)
 
-    def to_df(self, mode='all', by='line'):
+    def to_df(self, mode='all', by='line', line_num=None):
         """Entity-free per-parse DataFrame, built straight from the numpy arrays —
         constructs NO Parse objects (unlike ``.get_df``/``.scansions``, which
         materialize one Parse per scansion). ``by='line'``: one row per parse
@@ -1776,7 +1776,8 @@ class LazyParseList:
         P = len(parse_indices)
         if P == 0:
             return pd.DataFrame()
-        line_num = int(getattr(self.parent, 'num', 0) or 0)
+        line_num = int(line_num if line_num is not None
+                       else (getattr(self.parent, 'num', 0) or 0))
         if self._ragged:
             meter_strs = [_pool_meter_str(self, int(i)) for i in parse_indices]
             pp_viols = np.stack([self._all_viols[int(i)].sum(axis=0) for i in parse_indices]).astype(np.int32)

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -1742,6 +1742,75 @@ class LazyParseList:
         from .parselists import ParseList
         return ParseList(self.data, parse_unit=self.parse_unit, parent=self.parent).get_df(**kwargs)
 
+    def to_df(self, mode='all', by='line'):
+        """Entity-free per-parse DataFrame, built straight from the numpy arrays —
+        constructs NO Parse objects (unlike ``.get_df``/``.scansions``, which
+        materialize one Parse per scansion). ``by='line'``: one row per parse
+        (meter, score, per-constraint violation totals), with an ``is_bounded``
+        column. Default ``mode='all'`` returns EVERY parse (matching ``.parses``);
+        ``mode='unbounded'`` gives just the Pareto frontier (the rows
+        ``TextModel.get_parses_df(by='line')`` produces), ``mode='best'`` the top
+        one. Use ``TextModel.get_parses_df(by='syll')`` for the syllable frame (it
+        needs the text's syllable DataFrame)."""
+        import pandas as pd
+        if by != 'line':
+            raise NotImplementedError(
+                "LazyParseList.to_df supports by='line'; use "
+                "TextModel.get_parses_df(by='syll') for the syllable-level frame.")
+        unbounded_mask = self._unbounded_mask
+        all_scores = self._all_scores
+        unb_idx = self._unbounded_indices
+        rank_of = np.full(len(unbounded_mask), -1, dtype=np.int32)
+        if len(unb_idx) > 0:
+            ub_sorted = unb_idx[np.argsort(self._scores)]
+            rank_of[ub_sorted] = np.arange(1, len(ub_sorted) + 1, dtype=np.int32)
+            best_idx = int(ub_sorted[0])
+        else:
+            best_idx = -1
+        if mode == 'best':
+            parse_indices = np.array([best_idx], dtype=np.int64) if best_idx >= 0 else np.empty(0, dtype=np.int64)
+        elif mode == 'unbounded':
+            parse_indices = unb_idx[np.argsort(self._scores)]
+        else:
+            parse_indices = np.argsort(all_scores)
+        P = len(parse_indices)
+        if P == 0:
+            return pd.DataFrame()
+        line_num = int(getattr(self.parent, 'num', 0) or 0)
+        if self._ragged:
+            meter_strs = [_pool_meter_str(self, int(i)) for i in parse_indices]
+            pp_viols = np.stack([self._all_viols[int(i)].sum(axis=0) for i in parse_indices]).astype(np.int32)
+            num_sylls = np.array([self._all_viols[int(i)].shape[0] for i in parse_indices], dtype=np.int32)
+        else:
+            mv_arr = self._meter_vals
+            if mv_arr is None:
+                mv_arr, _, _ = encode_scansions(self._all_scansions, self._all_viols.shape[1])
+            meter_strs = [''.join('+' if v else '-' for v in mv_arr[i]) for i in parse_indices]
+            pp_viols = self._all_viols[parse_indices].sum(axis=1).astype(np.int32)
+            num_sylls = np.full(P, self._all_viols.shape[1], dtype=np.int32)
+        df = pd.DataFrame({
+            'line_num': np.full(P, line_num, dtype=np.int32),
+            'parse_idx': parse_indices.astype(np.int32),
+            'parse_rank': pd.array(rank_of[parse_indices], dtype='Int32'),
+            'parse_score': all_scores[parse_indices].astype(np.float64),
+            'is_best': parse_indices == best_idx,
+            'is_bounded': ~unbounded_mask[parse_indices],
+            'num_sylls': num_sylls,
+            'num_viols': pp_viols.sum(axis=1).astype(np.int32),
+            'meter': meter_strs,
+        })
+        df.loc[df['parse_rank'] < 0, 'parse_rank'] = pd.NA
+        for ci, cname in enumerate(self._constraint_names):
+            col = pp_viols[:, ci]
+            if col.any():
+                df[f'*{cname}'] = col.astype(np.int32)
+        return df
+
+    @property
+    def df(self):
+        """Entity-free per-parse DataFrame (see ``to_df``); builds no Parse objects."""
+        return self.to_df()
+
     def get_ld(self, **kwargs):
         from .parselists import ParseList
         return ParseList(self.data, parse_unit=self.parse_unit, parent=self.parent).get_ld(**kwargs)

--- a/prosodic/texts/lines.py
+++ b/prosodic/texts/lines.py
@@ -64,19 +64,10 @@ class Line(GridMethods, WordTokenList):
         if parse is None:
             parse = min(self._parses)
 
-        # DF-path parses use lightweight SyllData units with no wordtoken parent
-        # chain, so wordtoken2slots (below) can't map slots to words. Re-parse
-        # this line via the entity path (real Syllable entities) so rendering
-        # works after text.parse(). (AUDIT T9)
-        if getattr(parse, "wordtokens", None) is None:
-            from ..parsing.vectorized import parse_batch
-            meter = getattr(parse, "meter_obj", None) or self.meter
-            results = parse_batch([self], meter)
-            if results and results[0][1] is not None:
-                entity_best = results[0][1].best_parse
-                if entity_best is not None:
-                    parse = entity_best
-
+        # Both entity- and DF-path parses render directly: wordtoken2slots keys by
+        # the tokenizer word number (WordToken.num == SyllData.word_num), so a
+        # DF-path parse no longer needs an entity-path re-parse to map slots to
+        # words. (Was AUDIT T9's eager re-parse; now entity-free.)
         output = []
 
         for i, wordtoken in enumerate(self.wordtokens):
@@ -85,7 +76,7 @@ class Line(GridMethods, WordTokenList):
                 odx = {"txt": prefstr}
                 output.append(odx)
 
-            wordtoken_slots = parse.wordtoken2slots[wordtoken.key]
+            wordtoken_slots = parse.wordtoken2slots[wordtoken.num]
             if wordtoken_slots:
                 for slot in wordtoken_slots:
                     pos = slot.position

--- a/prosodic/texts/texts.py
+++ b/prosodic/texts/texts.py
@@ -552,6 +552,27 @@ class TextModel(Entity):
             line_results = self._line_parse_results[
                 next(reversed(self._line_parse_results))
             ]
+
+        # by='line' is the entity-free per-parse frame: delegate to the single
+        # source of truth (LazyParseList.to_df) per line, then union the per-line
+        # `*<constraint>` columns (a constraint absent from a line -> 0). by='syll'
+        # needs the syllable-level frame and is built by the loop below.
+        if by == 'line':
+            dfs = []
+            for ln in sorted(line_results.keys()):
+                pl = line_results[ln]
+                if pl is None or getattr(pl, '_all_viols', None) is None:
+                    continue
+                d = pl.to_df(mode=mode, by='line', line_num=ln)
+                if len(d):
+                    dfs.append(d)
+            if not dfs:
+                return pd.DataFrame()
+            df = pd.concat(dfs, ignore_index=True)
+            for c in [c for c in df.columns if c.startswith('*')]:
+                df[c] = df[c].fillna(0).astype('int32')
+            return df
+
         for line_num in sorted(line_results.keys()):
             pl = line_results[line_num]
             sylls = getattr(pl, '_sylls', None)
@@ -613,30 +634,6 @@ class TextModel(Entity):
             sel_mv = mv_arr[parse_indices]       # (P, N) bool
             sel_pi = pi_arr[parse_indices]       # (P, N) int
             sel_ps = ps_arr[parse_indices]       # (P, N) int
-
-            if by == 'line':
-                # one row per parse: collapse the N syllable axis. meter string
-                # uses '+' for strong positions, '-' for weak (matching
-                # Parse.meter_str); violations are summed over syllables (total
-                # per constraint per parse).
-                meter_strs = np.array(
-                    [''.join('+' if v else '-' for v in row) for row in sel_mv],
-                    dtype=object,
-                )
-                pp_viols = viols[parse_indices].sum(axis=1).astype(np.int32)  # (P, C)
-                chunks.append({
-                    'line_num': np.full(P, int(line_num), dtype=np.int32),
-                    'parse_idx': parse_indices.astype(np.int32),
-                    'parse_rank': rank_of[parse_indices],
-                    'parse_score': all_scores[parse_indices].astype(np.float64),
-                    'is_best': parse_indices == best_idx,
-                    'is_bounded': ~unbounded_mask[parse_indices],
-                    'num_sylls': np.full(P, N, dtype=np.int32),
-                    'meter': meter_strs,
-                    '_viols': pp_viols,
-                    '_c_names': pl._constraint_names,
-                })
-                continue
 
             PN = P * N
 
@@ -726,30 +723,8 @@ class TextModel(Entity):
         if not chunks:
             return pd.DataFrame()
 
-        if by == 'line':
-            def _cat(k):
-                return np.concatenate([c[k] for c in chunks])
-            viols_all = np.concatenate([c['_viols'] for c in chunks], axis=0)  # (P_total, C)
-            c_names = chunks[0]['_c_names']
-            df = pd.DataFrame({
-                'line_num': _cat('line_num'),
-                'parse_idx': _cat('parse_idx'),
-                'parse_rank': pd.array(_cat('parse_rank'), dtype='Int32'),
-                'parse_score': _cat('parse_score'),
-                'is_best': _cat('is_best'),
-                'is_bounded': _cat('is_bounded'),
-                'num_sylls': _cat('num_sylls'),
-                'num_viols': viols_all.sum(axis=1).astype(np.int32),
-                'meter': _cat('meter'),
-            })
-            df.loc[df['parse_rank'] < 0, 'parse_rank'] = pd.NA
-            for ci, cname in enumerate(c_names):
-                col = viols_all[:, ci]
-                if col.any():
-                    df[f'*{cname}'] = col.astype(np.int32)
-            return df
-
-        # Concatenate all chunks into DataFrame
+        # Concatenate all chunks into DataFrame (by='syll'; by='line' returned
+        # above via LazyParseList.to_df).
         base_cols = [
             'line_num', 'word_num', 'form_idx', 'syll_idx', 'line_syll_idx',
             'parse_idx', 'parse_rank', 'parse_score', 'is_best', 'is_bounded',

--- a/prosodic/web/api.py
+++ b/prosodic/web/api.py
@@ -326,11 +326,21 @@ def render_parse_html(parse, line=None):
                 return ent
         return None
 
+    # DF-path slots hold lightweight SyllData with no parent chain, so the walk
+    # above returns None. Fall back to the syllable's word_num -> WordToken map
+    # (SyllData.word_num and WordToken.num share the tokenizer's counter), so
+    # rendering works without building entities.
+    wt_by_num = {}
+    if line is not None and hasattr(line, 'wordtokens'):
+        wt_by_num = {wt.num: wt for wt in line.wordtokens}
+
     slots_by_wt = {}
     ordered_wt_ids = []
     for pos in parse.positions:
         for slot in pos.children:
             wt = _find_wordtoken(slot.unit)
+            if wt is None:
+                wt = wt_by_num.get(getattr(slot.unit, 'word_num', None))
             key = id(wt) if wt is not None else None
             if key not in slots_by_wt:
                 slots_by_wt[key] = []

--- a/tests/test_maxent.py
+++ b/tests/test_maxent.py
@@ -12,11 +12,15 @@ optimizer converges in well under a second on inputs this size.
 """
 import warnings
 
-# Import torch before prosodic so that, under `pytest --cov`, torch's C
-# docstrings are registered exactly once. Importing prosodic (hence torch)
-# while coverage's tracer is active otherwise re-triggers torch.overrides and
-# raises "function '_has_torch_function' already has a docstring" at collection.
-import torch  # noqa: F401
+# Pre-import torch (if installed) before prosodic so that, under `pytest --cov`,
+# torch's C docstrings register exactly once (importing prosodic while coverage's
+# tracer is active otherwise raises "function '_has_torch_function' already has a
+# docstring" at collection). torch is optional (GPU-only) and absent on e.g.
+# Windows CI, so guard it — the tests themselves don't require torch.
+try:
+    import torch  # noqa: F401
+except ModuleNotFoundError:
+    pass
 
 import numpy as np
 import pandas as pd

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -634,6 +634,28 @@ def test_ragged_pool_zone_scored():
     assert np.isfinite(rag.best_parse.score)                # no crash building parse
 
 
+def test_lazyparselist_df_entity_free():
+    """line.parses.df / .to_df build the parse DataFrame straight from numpy —
+    zero Parse objects — and to_df(mode='unbounded') matches get_parses_df(by=
+    'line'). Default mode='all' returns every parse (with is_bounded), no meter
+    dedup needed (scansions are already distinct meter strings)."""
+    t = TextModel("Shall I compare thee to a summers day")
+    t.parse()
+    pl = t.lines[0].parses
+    built_before = len(pl._built_parses)
+    df_all = pl.df                                   # mode='all'
+    assert len(pl._built_parses) == built_before     # built NO Parse objects
+    assert len(df_all) == len(pl._all_scansions)      # every scansion, one row
+    assert df_all.meter.nunique() == len(df_all)      # distinct meter strings
+    assert {'meter', 'parse_score', 'is_bounded', 'num_viols'} <= set(df_all.columns)
+    # unbounded slice matches the text-level entity-free frame for this line
+    dfu = pl.to_df(mode='unbounded')
+    assert len(pl._built_parses) == built_before      # still no Parse objects
+    g = t.get_parses_df(by='line')
+    assert sorted(dfu.meter.tolist()) == sorted(g.meter.tolist())
+    assert (~df_all.is_bounded).sum() == len(dfu)      # unbounded count consistent
+
+
 def test_num_words_df_path():
     """num_words works on the DF path (no wordform entities): it counts distinct
     word_num on the parse's SyllData slots. Regression — it used to return 0 when


### PR DESCRIPTION
Follow-through on the entity-ification investigation: **a Parse doesn't need entities for the common consumers** (`meter_str`/`score`/violations already work on DF-path `SyllData`), and now **rendering doesn't either**.

The render consumers reached the `WordToken` through `slot.unit`'s parent chain, which is `None` on the DF path — so they forced an eager entity re-parse. They now key off the tokenizer word number instead (`WordToken.num == SyllData.word_num`):

- **`render_parse_html`**: falls back to a `word_num → WordToken` map (from the `line` arg) when the parent walk returns `None`.
- **`Parse.wordtoken2slots`**: keys by `wordtoken.num` / `word_num` — works on both paths.
- **`Line.to_html`**: **drops the entity-path re-parse** (former AUDIT T9). A DF-path parse now renders directly with full meter/stress/violation CSS + punctuation.
- (`num_words` was already fixed on develop — counts distinct `word_num`.)

**Net:** after `text.parse()` (the fast DF path), `.to_html()`/`render_parse_html` no longer build `Syllable`/`Phoneme` entities. Verified: render + web tests pass; **517 total**.

**Remaining (separate, larger step):** the web endpoints still call `parse_batch` (entity path) directly for parse+render — they *could* now use `parse_batch_from_df` to also drop the eager `Syllable` construction in `extract_features`, but that's coupled to `parse_batch`'s `(wt, pl)` return shape and the linepart Pass-2 / detail endpoint, so it warrants its own verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)