### PR TITLE
web /api/parse: parse short lines via the DF path (drop eager entities)

### DIFF
--- a/prosodic/web/api.py
+++ b/prosodic/web/api.py
@@ -711,22 +711,27 @@ def _parse_and_build_rows(t, meter):
     """Parse lines + (for any long line) its lineparts. Return combined rows,
     sorted by line_num, rank. Returns (rows, num_lines, prose_mode_flag).
     """
-    from prosodic.parsing.vectorized import parse_batch
+    from prosodic.parsing.vectorized import parse_batch, parse_batch_from_df
 
     long_lnums = _long_line_nums(t)
     prose_mode = len(long_lnums) > 0
 
-    # Pass 1: parse short lines normally
+    # Pass 1: short lines via the entity-free DF path (parse_batch_from_df) — no
+    # eager Syllable/Phoneme trees. render_parse_html and the render loop below
+    # work on the resulting SyllData parses (grouped by word_num). Long lines are
+    # handled by their lineparts in Pass 2 (entity path — they aren't line-keyed
+    # in the syllable frame and would blow up the DF-path candidate space).
     short_lines = [ln for ln in t.lines if ln.num not in long_lnums]
     if short_lines:
         meter.parse_unit = 'line'
-        results = parse_batch(short_lines, meter)
-        for i, (wt, pl) in enumerate(results):
-            if pl is None:
-                continue
-            pl.parent = wt
-            wt._parses = pl
-            short_lines[i]._parses = pl
+        short_nums = {ln.num for ln in short_lines}
+        short_sdf = t._syll_df[t._syll_df['line_num'].isin(short_nums)]
+        results = parse_batch_from_df(short_sdf, meter)  # {line_num: LazyParseList}
+        for ln in short_lines:
+            pl = results.get(ln.num)
+            if pl is not None:
+                pl.parent = ln
+                ln._parses = pl
 
     # Pass 2: for long lines, parse their lineparts (with optional syntax sub-split)
     from collections import OrderedDict


### PR DESCRIPTION
Completes the lazy-entity line: the **hot web parse path** (`/api/parse` + `/api/parse/stream`) no longer builds `Syllable`/`Phoneme` trees just to render.

Previously it parsed short lines with `parse_batch` (entity path) purely because `render_parse_html` needed a parent chain. Now that rendering keys off `word_num` (the prior entity-free-render PR), Pass 1 uses **`parse_batch_from_df`** on the short-line slice of the syllable frame and attaches the resulting `LazyParseList`s by `line_num`. The render loop is unchanged — it works on the `SyllData` parses.

**Scope (kept minimal / verifiable):**
- Long lines' lineparts (Pass 2) stay on `parse_batch` — they aren't line-keyed in the frame and >18-syll lines would blow up the DF candidate space.
- The single-line `/api/parse/line` detail view (grid + syntax-tree figure) stays on `parse_batch` — more coupled, non-hot, its own follow-up.

**Verification:**
- FastAPI web tests: 29 pass.
- **Live Playwright spot-check**: typed a line, clicked Parse → `POST /api/parse/stream` 200 → the `fog` syllable rendered with `mtr_s str_s viol_n` (screenshot shared).
- Full suite: 518 pass.

Stacks conceptually on the merged entity-free-render work. Recommend a quick live spot-check of the deployed UI before this ships to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)