### PR TITLE
Coverage 80% → 91%: exclude vendored lib, +157 tests, fix maxent bug

### DIFF
--- a/prosodic/web/api.py
+++ b/prosodic/web/api.py
@@ -1135,16 +1135,18 @@ async def maxent_fit_annotations(
     df = pd.read_csv(io.BytesIO(content), sep='\t')
 
     if 'text' not in df.columns:
+        # Map source columns -> canonical names. rename() takes {old: new}, so
+        # key by the actual column and value by the canonical name.
         col_map = {}
         for col in df.columns:
             cl = col.lower()
             if 'line' in cl or 'text' in cl:
-                col_map['text'] = col
+                col_map[col] = 'text'
             elif 'parse' in cl or 'scan' in cl:
-                col_map['scansion'] = col
+                col_map[col] = 'scansion'
             elif 'freq' in cl or 'count' in cl:
-                col_map['frequency'] = col
-        if 'text' not in col_map:
+                col_map[col] = 'frequency'
+        if 'text' not in col_map.values():
             raise HTTPException(status_code=400, detail=f"Cannot find text column. Columns: {list(df.columns)}")
         df = df.rename(columns=col_map)
     if 'frequency' not in df.columns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,7 @@ prosodic = "prosodic.cli:cli"
 markers = [
     "slow: marks tests as slow (deselect with -k \"not slow\")",
 ]
+[tool.coverage.run]
+# prosodic/lib/ is vendored third-party (panphon, metricaltree, syllabiphon) —
+# not our code, so exclude it from prosodic's coverage figures.
+omit = ["prosodic/lib/*", "*/prosodic/lib/*"]

--- a/tests/test_ents.py
+++ b/tests/test_ents.py
@@ -270,3 +270,446 @@ def test_serialize():
             assert attrd1 == attrd2
 
     do(t)
+
+
+# ---------------------------------------------------------------------------
+# The tests below target Entity/EntityList base-class methods in ents.py that
+# were previously uncovered. Each builds a small TextModel and asserts concrete
+# tree structure/behavior. See module-level notes on genuinely-dead branches.
+# ---------------------------------------------------------------------------
+
+
+def test_copy_entity_and_list():
+    # copy() has two branches: children is an EntityList vs a plain list.
+    t = TextModel('hello bright world')
+    tc = t.copy()
+    assert tc is not t
+    assert type(tc) is TextModel
+    assert tc.txt == t.txt
+    # copy is a distinct object graph
+    assert tc.children is not t.children
+
+    # A Stanza's children is a plain list -> exercises the else branch.
+    st = t.stanzas[0]
+    stc = st.copy()
+    assert stc is not st
+    assert stc.txt == st.txt
+    assert type(stc) is type(st)
+
+
+def test_clear_cached_properties():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # Populate some cached_property values.
+    _ = line.root
+    _ = line.ancestors
+    assert 'root' in line.__dict__
+    assert 'ancestors' in line.__dict__
+    line.clear_cached_properties()
+    assert 'root' not in line.__dict__
+    assert 'ancestors' not in line.__dict__
+    # Recomputable afterwards.
+    assert line.root is t
+
+
+def test_list_type_and_type_name_and_type():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # Entity.list_type (base) resolves the *List class for a non-list entity.
+    assert t.syllables[0].list_type is SyllableList
+    # A Line is itself an EntityList, so it uses the override (own class).
+    assert line.list_type is Line
+    # EntityList.list_type returns its own class.
+    assert t.stanzas.list_type is StanzaList
+    # type_name: plain lowercase; list classes get pluralized.
+    assert line.type_name == 'line'
+    assert t.stanzas.type_name == 'stanzas'
+    # .type returns the concrete class.
+    assert line.type is Line
+    # nice_type_name strips Model/Class.
+    assert t.nice_type_name == 'Text'
+
+
+def test_get_class_and_child_type():
+    assert Entity._get_class('line') is Line
+    assert Entity._get_class('stanza') is Stanza
+    t = TextModel('hello world')
+    # A list class exposes its singular child_type name; a non-list -> None.
+    assert t.stanzas.child_type == 'Stanza'
+    assert t.lines[0].child_type is None
+
+
+def test_is_wordtokenlist():
+    t = TextModel('hello world')
+    assert t.wordtokens.is_wordtokenlist is True
+    # A Line *is* a WordTokenList subclass in this architecture.
+    assert t.lines[0].is_wordtokenlist is True
+    # A Syllable is not.
+    assert t.syllables[0].is_wordtokenlist is False
+
+
+def test_getitem_slice_sets_metadata():
+    # Slicing an EntityList returns a same-class instance; __getitem__ then
+    # copies over _text/parent (lines 197-198).
+    t = TextModel('hello there big world')
+    sl = t.wordtokens[0:2]
+    assert type(sl) is WordTokenList
+    assert len(sl) == 2
+    assert sl is not t.wordtokens
+
+
+def test_getattr_dynamic_magic():
+    t = TextModel('hello world foo bar')
+    # digit-suffixed singular -> nth child (1-based).
+    assert t.line1 is t.lines[0]
+    assert t.syll2 is t.syllables[1]
+    # out-of-range digit index -> None (IndexError branch).
+    assert t.line999 is None
+    # <name>_r -> a random one of that type.
+    assert type(t.syllable_r) is Syllable
+    # <name>_span -> (first.num, last.num).
+    assert t.syllable_span == (t.syllables[0].num, t.syllables[-1].num)
+    # num_<type> -> count.
+    assert t.num_lines == 1
+    assert t.num_syllables == len(t.syllables)
+
+
+def test_get_list_branches():
+    t = TextModel('hello world foo')
+    line = t.lines[0]
+    # Unknown type -> None (list_class is None).
+    assert line.get_list('nonexistenttype') is None
+    # Asking a list for its own type returns self.
+    assert t.stanzas.get_list('stanza') is t.stanzas
+    # An entity whose children ARE the requested list returns those children.
+    wt = t.wordtokens[0]
+    assert wt.get_list('wordtype') is wt.children
+    # A punctuation token has no syllable descendants -> None.
+    t2 = TextModel('hello, world!')
+    puncs = [w for w in t2.wordtokens if w.is_punc]
+    assert puncs, 'expected punctuation tokens'
+    assert puncs[0].get_list('syllable') is None
+
+
+def test_children_keys_set_and_descendants():
+    t = TextModel('hello world')
+    assert isinstance(t.children_keys, set)
+    assert len(t.children_keys) == len(t.children)
+    assert isinstance(t.children_set, set)
+    assert len(t.children_set) == len(t.children)
+    # descendants maps key -> obj and includes self.
+    desc = t.descendants
+    assert isinstance(desc, dict)
+    assert t.key in desc
+    assert isinstance(t.descendant_keys, set)
+    assert t.descendant_keys == set(desc.keys())
+
+
+def test_get_ancestor_and_descendants_helpers():
+    t = TextModel('hello world')
+    syll = t.syllables[0]
+    # Ancestors that exist above the syllable in the parent chain.
+    wt = syll._get_ancestor('wordtoken')
+    assert wt is not None and type(wt) is WordToken
+    assert syll._get_ancestor('text') is t
+    # A type that is NOT an ancestor (deeper than syllable) -> None.
+    assert syll._get_ancestor('phoneme') is None
+    # get_descendants of a deeper type returns entities; of a shallower/absent
+    # type returns an empty list.
+    assert len(t.get_descendants('phoneme')) == len(t.phonemes)
+    assert t.get_descendants('stanza') == []
+
+
+def test_contains_branches():
+    t = TextModel('hello world\nfoo bar baz')
+    line0, line1 = t.lines[0], t.lines[1]
+    # self contains self.
+    assert t.contains(t) is True
+    # Text contains a descendant line (key-prefix match).
+    assert t.contains(line0) is True
+    # Text contains a descendant EntityList.
+    assert t.contains(t.stanzas) is True
+    # A deeper entity does not contain a shallower one.
+    assert t.wordtokens[0].contains(line0) is False
+    assert t.syllables[0].contains(line0) is False
+    # Two sibling lines: one does not contain a wordtoken of the other.
+    other_wt = line1.wordtokens[0]
+    assert line0.contains(other_wt) is False
+
+
+def test_get_random_and_get_one():
+    t = TextModel('hello world foo bar')
+    assert type(t.get_random('line')) is Line
+    assert t.get_random('nonexistenttype') is None
+    assert t.get_one('line') is t.lines[0]
+    assert t.get_one('nonexistenttype') is None
+
+
+def test_wordforms_helpers():
+    t = TextModel('hello, world!')
+    first = t.wordforms_first
+    assert type(first) is WordFormList
+    # wordforms_first: the first form of each wordtype that HAS forms
+    # (punctuation wordtypes have no forms and are skipped).
+    assert len(first) == len([w for w in t.wordtypes if w.children])
+    # nopunc keeps only non-punctuation forms.
+    nopunc = t.wordforms_nopunc
+    assert type(nopunc) is WordFormList
+    assert len(nopunc) == len([wf for wf in first if not wf.is_punc])
+    assert all(not wf.is_punc for wf in nopunc)
+    # wordforms_all: list of per-wordtype form lists.
+    allforms = t.wordforms_all
+    assert type(allforms) is list
+    assert all(type(x) is WordFormList for x in allforms)
+    # Counts.
+    assert t.num_wordforms_all == sum(len(wt.children) for wt in t.wordtypes)
+    assert t.num_wordforms_nopunc == len(
+        [wf for wf in t.wordforms if not wf.parent.is_punc])
+
+
+def test_hash_id_equality():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # to_hash / hash / id are stable strings; __hash__ is an int.
+    assert isinstance(line.to_hash(), str) and line.to_hash()
+    assert isinstance(line.hash, str) and line.hash
+    assert isinstance(line.id, str) and line.id
+    assert isinstance(hash(line), int)
+    # Identity-based equality.
+    assert line == line
+    assert line == t.lines[0]  # same underlying object (cached)
+    assert not (line == t)
+    assert line != t.wordtokens[0]
+    # Hashable + usable in a set.
+    assert line in {line}
+
+
+def test_serialization_roundtrip_properties():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    assert isinstance(line.stuffed, dict)
+    assert line.unstuffed is not None
+    assert isinstance(line.serialized, (bytes, bytearray))
+    d = line.deserialized
+    assert type(d) is Line and d.key == line.key
+    # classmethod deserialize on serialized bytes.
+    d2 = Entity.deserialize(line.serialized)
+    assert type(d2) is Line and d2.key == line.key
+
+
+def test_ancestors_root_grandparent_prefixkey_id():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # ancestors walk up to (but excluding) self, ending at the root text.
+    anc = line.ancestors
+    assert anc[-1] is t
+    assert t in anc
+    assert line.root is t
+    # grandparent = parent.parent.
+    assert line.grandparent is t
+    # grandparent on the root text -> None (parent is None).
+    assert t.grandparent is None
+    # prefix_key resolves from the class registry.
+    assert line.prefix_key == 'Line'
+
+
+def test_key_without_parent_raises():
+    # A parentless entity with no explicit key cannot form a key.
+    e = Entity()
+    assert e.parent is None
+    with pytest.raises(AttributeError):
+        _ = e.key
+
+
+def test_wordspan_and_txt_join():
+    t = TextModel('hello world foo')
+    line = t.lines[0]
+    span = line.wordspan
+    assert span == (line.wordtokens[0].num, line.wordtokens[-1].num)
+    # Entity.txt lazily joins children when _txt is unset.
+    syll = t.syllables[0]
+    syll._txt = None
+    joined = syll.txt
+    assert joined == ''.join(p.txt for p in syll.children)
+    assert joined
+
+
+def test_to_dict_variants_and_save_and_reduce():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # incl_txt + extra kwargs land in the payload.
+    d = line.to_dict(incl_txt=True, extra='xyz')
+    payload = d['Line']
+    assert payload['txt'] == line._txt
+    assert payload['extra'] == 'xyz'
+    assert 'children' in payload
+    # incl_children=False omits children.
+    d2 = line.to_dict(incl_children=False)
+    assert 'children' not in d2['Line']
+    # incl_attrs=True copies _attrs into the payload.
+    line._attrs = {'foo': 'bar'}
+    d3 = line.to_dict(incl_attrs=True)
+    assert d3['Line']['foo'] == 'bar'
+    # save() delegates to to_dict (returns a dict, does not raise).
+    assert isinstance(line.save('unused.json'), dict)
+    # __reduce__ returns (Entity.from_dict, (dict,)) and round-trips.
+    fn, args = line.__reduce__()
+    assert fn.__func__ is Entity.from_dict.__func__
+    assert isinstance(args[0], dict)
+    rebuilt = fn(*args)
+    assert rebuilt.key == line.key
+
+
+def test_from_dict_dispatch_and_multi_raises():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # Entity.from_dict dispatches to the concrete subclass named in the dict.
+    obj = Entity.from_dict(line.to_dict(), use_registry=False)
+    assert type(obj) is Line
+    assert obj.key == line.key
+    # More than one top-level class key is an error.
+    with pytest.raises(AssertionError):
+        Entity.from_dict({'Line': {}, 'Stanza': {}})
+
+
+def test_html_and_render_after_parse():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    line.parse()
+    # html property delegates to to_html().
+    assert line.html is not None
+    # Base Entity.render delegates to to_html(as_str=...). Line overrides
+    # render, so call the base implementation directly.
+    rendered = Entity.render(line, as_str=True)
+    assert isinstance(rendered, str)
+    assert '<' in rendered
+    assert rendered == line.to_html(as_str=True)
+
+
+def test_repr_and_reprhtml_and_ld_df_helpers():
+    t = TextModel('hello world')
+    line = t.lines[0]
+    # __repr__ includes num/txt-style kwargs.
+    r = repr(line)
+    assert r.startswith('Line(')
+    # EntityList __repr__ is the multi-line indented form. A StanzaList's
+    # items are themselves EntityLists (recursive branch); a WordTokenList's
+    # items are plain entities (the repr(item) branch).
+    rl = repr(t.stanzas)
+    assert rl.startswith('StanzaList([')
+    assert '\n' in rl
+    rw = repr(t.wordtokens)
+    assert rw.startswith('WordTokenList([')
+    assert 'WordToken(' in rw
+    # ld / data / l / df accessors.
+    assert isinstance(line.ld, list) and line.ld
+    assert line.data is line.children
+    assert line.l is line.children
+    assert isinstance(line.df, pd.DataFrame)
+    # child_class resolves the singular child entity class of a list.
+    assert t.stanzas.child_class is Stanza
+    # _repr_html_ with a custom df exercises the blank(None) path (object
+    # dtype preserves the literal None the blank() helper checks for).
+    df = pd.DataFrame({'a': ['x', None]}, dtype=object)
+    html = line._repr_html_(df=df)
+    assert '<table' in html
+
+
+def test_get_df_unbool_and_badcols():
+    t = TextModel('hello world')
+    # get_df runs bool->int coercion via unbool over syllable feature columns.
+    df = t.get_df(incl_phons=False, incl_sylls=True)
+    import numpy as _np
+    vals = set(_np.ravel(df.values).tolist())
+    # Booleans are coerced to 0/1.
+    assert 0 in vals or 1 in vals
+    assert not any(v is True or v is False for v in vals)
+
+
+def test_inspect_maxlines_truncates():
+    import io
+    import contextlib
+    t = TextModel('hello world\nfoo bar baz')
+    # Top-level inspect() prints and returns None.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ret = t.inspect(maxlines=2)
+    assert ret is None
+    out = buf.getvalue().rstrip('\n')
+    assert len(out.split('\n')) <= 2
+
+
+def test_sibling_navigation_and_index():
+    t = TextModel('one two here\nthree four there')
+    line0, line1 = t.lines[0], t.lines[1]
+    # next / prev link siblings; boundaries return None.
+    assert line0.next is line1
+    assert line1.prev is line0
+    assert line0.prev is None
+    assert line1.next is None
+    # i / num relationships.
+    assert line0.i == 0 and line0.num == 1
+    assert line1.i == 1 and line1.num == 2
+    # The root text has no parent -> i/num/next/prev are None.
+    assert t.i is None
+    assert t.num is None
+    assert t.next is None
+    assert t.prev is None
+
+
+def test_meter_get_set_inherit():
+    from prosodic.parsing.meter import Meter
+    t = TextModel('one two three')
+    line = t.lines[0]
+    # Explicitly set a meter object.
+    m = Meter(max_s=2)
+    assert line.get_meter(m) is m
+    # No args -> unchanged.
+    assert line.get_meter() is m
+    # Different kwargs -> a new meter.
+    m2 = line.get_meter(max_s=3)
+    assert m2 is not m and m2.max_s == 3
+    # Same kwargs again -> no change.
+    assert line.get_meter(max_s=3) is m2
+    # set_meter / meter property.
+    line.set_meter(max_w=2)
+    assert line.meter.max_w == 2
+    # Sibling entities inherit the text-level meter.
+    t2 = TextModel('alpha beta gamma')
+    ml = t2.lines[0].get_meter()
+    assert t2.wordtokens[0].get_meter() is ml
+
+
+def test_entitylist_bool_txt_istextlist_children_type():
+    t = TextModel('hello world')
+    # __bool__: non-empty vs empty.
+    assert bool(t.stanzas) is True
+    assert bool(StanzaList(parent=t)) is False
+    # Base EntityList.txt is None (StanzaList does not override it).
+    assert t.stanzas.txt is None
+    # is_text_list: a list whose parent is the text.
+    assert t.stanzas.is_text_list
+    # children_type property runs (a class or None).
+    ct = t.stanzas.children_type
+    assert ct is None or isinstance(ct, type)
+
+
+def test_entitylist_append_sets_parent():
+    t = TextModel('hello world')
+    sl = StanzaList(parent=t)
+    st = TextModel('foo bar').stanzas[0]
+    # st has a parent already; append should not steal it, only add.
+    n = len(sl.children)
+    sl.append(st)
+    assert len(sl.children) == n + 1
+    assert sl.children[-1] is st
+    # Appending a parentless entity adopts the list as its parent.
+    orphan = Stanza()
+    sl.append(orphan)
+    assert orphan.parent is sl
+
+
+def test_module_get_class():
+    from prosodic.ents import get_class
+    assert get_class('Line') is Line
+    assert get_class('Stanza') is Stanza

--- a/tests/test_langs.py
+++ b/tests/test_langs.py
@@ -355,3 +355,281 @@ def test_syllabify_ipa_token_seg_alignment():
     assert len(en.syllabify_ipa("f ˈaɪ ə ɹ")) == 2         # fire
     # German-style secondary-stressed hiatus after a diphthong+cluster
     assert len(en.syllabify_ipa("ˈaʊ f ʃ t ˌeː ə n")) == 3  # aufstehen
+
+
+# ---------------------------------------------------------------------------
+# LanguageModel pronunciation-layer internals (langs.py coverage)
+# ---------------------------------------------------------------------------
+from prosodic.langs import langs as _lm
+from prosodic.langs.langs import (
+    LanguageModel,
+    Language,
+    get_word,
+    fix_num_sylls,
+    unstress,
+    stress,
+    stress_sylls_ipa_l,
+    syll_ipa_str_is_unstressed,
+    sylls_ipa_l_has_unstress,
+    get_espeak_error_msg,
+    get_espeak_env,
+)
+
+
+def test_getitem_delegates_to_get():
+    """LanguageModel.__getitem__ is sugar for .get() (line 44)."""
+    lang = EnglishLanguage()
+    got = lang["with"]
+    assert got == lang.get("with")
+    # get_sylls_ll payload: one pronunciation, one (ipa, text) syllable pair
+    assert got[0] == [[("wɪð", "with")]]
+
+
+def test_ipa_origin_dict_vs_tts(tmp_path):
+    """A CMU-dictionary word reports ipa_origin='dict'; a nonce word falls back
+    to espeak/TTS (ipa_origin='tts', line 333), the raw pronunciation is written
+    to the user-local cache (lines 258-269), and the in-memory map is updated so
+    a repeat lookup this session resolves from the dict."""
+
+    class _TmpCacheEnglish(EnglishLanguage):
+        @property
+        def path_token2ipa_cache(self):
+            return str(tmp_path / "english_cache.tsv")
+
+    lang = _TmpCacheEnglish()
+    # dictionary hit
+    _, meta = lang.get_sylls_ipa_ll("with")
+    assert meta["ipa_origin"] == "dict"
+    # espeak fallback for a word absent from CMU
+    ll, meta = lang.get_sylls_ipa_ll("zzblorptx")
+    assert meta["ipa_origin"] == "tts"
+    assert ll and ll[0]
+    cache = tmp_path / "english_cache.tsv"
+    assert cache.exists()
+    assert "zzblorptx" in cache.read_text(encoding="utf-8")
+    # second lookup (different force arg -> distinct cache key) resolves 'dict',
+    # not a re-run of espeak, because the in-memory map was updated
+    _, meta2 = lang.get_sylls_ipa_ll("zzblorptx", force_unstress=True)
+    assert meta2["ipa_origin"] == "dict"
+
+
+def test_ipa_origin_error_when_tts_empty(tmp_path):
+    """If neither the dictionary nor TTS yields a pronunciation, ipa_origin is
+    'error' and an empty parse is returned (lines 270-272)."""
+
+    class _NoTTS(EnglishLanguage):
+        @property
+        def path_token2ipa_cache(self):
+            return str(tmp_path / "c.tsv")
+
+        def get_sylls_ipa_ll_tts(self, token):
+            return []
+
+    ll, meta = _NoTTS().get_sylls_ipa_ll("zznovowelq")
+    assert meta["ipa_origin"] == "error"
+    assert ll == []
+
+
+def test_trailing_apostrophe_strip_on_miss():
+    """A bare trailing apostrophe survives tokenization; the lookup tries the
+    original token first, then strips the apostrophe ONLY on a dict miss
+    (line 251) -- while genuine apostrophe-final CMU keys hit directly."""
+    lang = EnglishLanguage()
+    # that' -> misses "that'", falls back to "that" (an ambig-stress entry:
+    # unstressed + stressed = 2 forms), origin still 'dict'
+    ll, meta = lang.get_sylls_ipa_ll("that'")
+    assert meta["ipa_origin"] == "dict"
+    assert len(ll) == 2
+    assert ll == lang.get_sylls_ipa_ll("that")[0]
+    # augustus' -> strips to "augustus"; CMU stress is a-GUS-tus (2nd syllable)
+    ll, meta = lang.get_sylls_ipa_ll("augustus'")
+    assert meta["ipa_origin"] == "dict"
+    assert len(ll) == 1
+    stressed = [i for i, s in enumerate(ll[0]) if s[:1] in ("'", "`")]
+    assert stressed == [1], f"augustus' should stress syll 1, got {ll[0]}"
+    # runnin' -> a genuine CMU key ending in apostrophe: hit directly, NOT stripped
+    ll, meta = lang.get_sylls_ipa_ll("runnin'")
+    assert meta["ipa_origin"] == "dict"
+    assert len(ll[0]) == 2  # run-nin
+
+
+def test_elision_wiring_flower_fire_heaven():
+    """With EnglishLanguage.use_elision on, get_sylls_ipa_ll adds a reduced-
+    syllable variant alongside the full pronunciation (lines 283-290); the base
+    LanguageModel elides nothing (line 201)."""
+    lang = EnglishLanguage()
+    assert lang.use_elision is True
+    for w in ("flower", "fire", "heaven"):
+        ll, _ = lang.get_sylls_ipa_ll(w)
+        lens = sorted(len(x) for x in ll)
+        assert lens == [1, 2], f"{w}: expected 1-syll elision + 2-syll base, got {ll}"
+    # get_elided_pronunciations directly: fire ('faɪ.ɛː -> 'faɪr)
+    assert lang.get_elided_pronunciations(["'faɪ", "ɛː"]) == [["'faɪr"]]
+    # base language elides nothing
+    assert LanguageModel().get_elided_pronunciations(["'faɪ", "ɛː"]) == []
+
+
+def test_force_ambig_stress_synthesizes_missing_polarity():
+    """force_ambig_stress adds whichever stress polarity is missing: a stressed
+    variant when the pronunciation is unstressed-only (line 299) and an
+    unstressed variant when it is stressed-only (line 301)."""
+
+    class _UnstrOnly(LanguageModel):
+        def get_sylls_ipa_ll_dict(self, token):
+            return [["bə"]]
+
+    ll, _ = _UnstrOnly().get_sylls_ipa_ll("x", force_ambig_stress=True)
+    assert sorted(ll) == [["'bə"], ["bə"]]
+
+    class _StrOnly(LanguageModel):
+        def get_sylls_ipa_ll_dict(self, token):
+            return [["'bə"]]
+
+    ll, _ = _StrOnly().get_sylls_ipa_ll("x", force_ambig_stress=True)
+    assert sorted(ll) == [["'bə"], ["bə"]]
+
+
+def test_ambig_and_unstress_membership():
+    """Membership drives forcing: 'the' is unstressed-only; 'she' is in BOTH
+    lists, so ambiguous-stress wins (2 forms, can bear a beat)."""
+    lang = EnglishLanguage()
+    assert "the" in lang.unstressed_words
+    assert "she" in lang.ambig_stressed_words and "she" in lang.unstressed_words
+    _, meta = lang.get_sylls_ipa_ll("the")
+    assert meta["force_unstress"] is True and meta["force_ambig_stress"] is None
+    ll, meta = lang.get_sylls_ipa_ll("she")
+    assert meta["force_ambig_stress"] is True
+    assert len(ll) == 2  # stressed + unstressed
+
+
+def test_base_language_defaults():
+    """The base LanguageModel (no name) has empty membership sets, a null TTS
+    cache path (line 90), and inert rule/cache hooks (lines 148, 185, 195)."""
+    b = LanguageModel()
+    assert b.name is None
+    assert b.path_token2ipa_cache is None
+    assert b.unstressed_words == set()
+    assert b.ambig_stressed_words == set()
+    assert b.get_sylls_ipa_ll_rule("x") == ([], {})
+    assert b.get_sylls_ll_rule("x") == ([], {})
+    # best-effort disk hooks no-op when there is no cache path
+    b._dedupe_cache_file()
+    b._cache_tts_result("foo", ["'fu"])
+
+
+def test_load_token2ipa_file_direct(tmp_path):
+    """_load_token2ipa_file defaults its accumulators (lines 116, 118) and skips
+    exact-duplicate (token, pronunciation) rows while keeping distinct
+    pronunciation variants (line 129)."""
+    p = tmp_path / "dict.tsv"
+    p.write_text(
+        "cat\t'kæt\n"
+        "cat\t'kæt\n"   # exact duplicate -> skipped
+        "cat\tk.'æt\n"  # distinct variant -> kept
+        "dog\t'dɔɡ\n"
+        "notabhere\n"   # no separator -> ignored
+        "\n",           # blank -> ignored
+        encoding="utf-8",
+    )
+    d = LanguageModel()._load_token2ipa_file(str(p))
+    assert d["cat"] == [["'kæt"], ["k", "'æt"]]
+    assert d["dog"] == [["'dɔɡ"]]
+    assert "notabhere" not in d
+
+
+def test_stress_helper_functions():
+    """Small IPA stress utilities (lines 518, 525-529, 533, 549, 553)."""
+    assert unstress("") == ""
+    assert unstress("'maɪ") == "maɪ"
+    assert stress("") == ""
+    assert stress("maɪ") == "'maɪ"
+    assert stress("maɪ", primary=False) == "`maɪ"
+    assert stress("'maɪ") == "'maɪ"  # already stressed -> normalized, re-marked
+    assert stress_sylls_ipa_l(["maɪ", "naɪs"]) == ["'maɪ", "`naɪs"]
+    assert syll_ipa_str_is_unstressed("maɪ") is True
+    assert syll_ipa_str_is_unstressed("'maɪ") is False
+    assert sylls_ipa_l_has_unstress(["'maɪ", "naɪs"]) is True
+    assert sylls_ipa_l_has_unstress(["'maɪ"]) is False
+
+
+def test_fix_num_sylls_shrink_and_grow():
+    """fix_num_sylls merges when there are too many syllables (lines 508-509)
+    and splits when there are too few; empty pieces become '?'."""
+    assert fix_num_sylls(["a", "b", "c"], 2) == ["a", "bc"]
+    assert fix_num_sylls(["abcd"], 2) == ["ab", "cd"]
+    assert fix_num_sylls([""], 1) == ["?"]
+
+
+def test_get_espeak_error_msg_lists_paths():
+    """The espeak-not-found message names espeak and echoes the searched
+    paths (lines 593-594)."""
+    msg = get_espeak_error_msg(["/opt/none", "/usr/none"])
+    assert "espeak" in msg.lower()
+    assert "/opt/none" in msg and "/usr/none" in msg
+
+
+def test_glob_espeak_lib(tmp_path):
+    """_glob_espeak_lib prefers an unversioned filename, else falls back to the
+    first sorted match, and returns '' when nothing matches (lines 675-686)."""
+    (tmp_path / "libespeak.dylib").write_text("")
+    (tmp_path / "libespeak.so.1").write_text("")
+    pat = str(tmp_path / "libespeak*")
+    # preferred (unversioned) name wins even though .so.1 also matches
+    assert _lm._glob_espeak_lib(globs=[pat], preferred={"libespeak.dylib"}) == str(
+        tmp_path / "libespeak.dylib"
+    )
+    # no preferred match -> first in sorted order (libespeak.dylib < libespeak.so.1)
+    assert _lm._glob_espeak_lib(globs=[pat], preferred={"nope"}) == str(
+        tmp_path / "libespeak.dylib"
+    )
+    # nothing matches -> ''
+    assert _lm._glob_espeak_lib(globs=[str(tmp_path / "zzz*")], preferred=set()) == ""
+
+
+def test_find_espeak_lib_recursive_skips(tmp_path):
+    """_find_espeak_lib_recursive skips non-directories (700) and broad system
+    dirs (702), returns '' when nothing is found (712), and returns a real
+    nested hit."""
+    nondir = str(tmp_path / "does_not_exist")
+    # non-dir path + a NO_RECURSE system dir -> ''
+    assert _lm._find_espeak_lib_recursive([nondir, "/usr/lib"], {"libespeak.so"}) == ""
+    # a real nested library is found
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    lib = nested / "libespeak.so"
+    lib.write_text("")
+    assert _lm._find_espeak_lib_recursive([str(tmp_path)], {"libespeak.so"}) == str(lib)
+
+
+def test_get_espeak_env_direct_file(tmp_path, monkeypatch):
+    """A configured path that IS an espeak library file is returned directly
+    (lines 730, 732-733)."""
+    monkeypatch.delenv("PATH_ESPEAK", raising=False)
+    monkeypatch.delenv("PHONEMIZER_ESPEAK_LIBRARY", raising=False)
+    libfile = tmp_path / "libespeak.dylib"
+    libfile.write_text("")
+    assert get_espeak_env([str(libfile)]) == str(libfile)
+
+
+def test_get_espeak_env_glob_fallback_and_warning(monkeypatch):
+    """With no usable configured path, get_espeak_env falls back to the system
+    glob (lines 747-749); if even that fails it warns and returns '' (750-751)."""
+    monkeypatch.delenv("PATH_ESPEAK", raising=False)
+    monkeypatch.delenv("PHONEMIZER_ESPEAK_LIBRARY", raising=False)
+    # on this machine / CI espeak is installed, so the system glob resolves it
+    found = _lm._glob_espeak_lib()
+    if found:
+        assert get_espeak_env([]) == found
+    # force the glob to fail -> warning path, returns ''
+    monkeypatch.setattr(_lm, "_glob_espeak_lib", lambda *a, **k: "")
+    assert get_espeak_env([]) == ""
+
+
+def test_language_factory_de_generic_and_get_word():
+    """Language() dispatches to the German subclass and to a bare LanguageModel
+    for an unknown code (lines 775-782); get_word routes through Language().get()."""
+    assert type(Language("de")).__name__ == "GermanLanguage"
+    generic = Language("zz")
+    assert type(generic) is LanguageModel
+    assert generic.lang == "zz"
+    assert get_word("with", lang="en")[0] == Language("en").get("with")[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,492 @@
+"""Tests for prosodic/utils.py — the small stateless helpers.
+
+These functions have no linguistic dependencies, so every assertion here is on
+an exact, hand-computed output. conftest.py puts the repo root on sys.path.
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from prosodic.imports import pd, np, logmap, GLOBALS
+import prosodic.utils as U
+
+
+# ---------------------------------------------------------------------------
+# retry_on_io_error
+# ---------------------------------------------------------------------------
+
+def test_retry_succeeds_after_transient_failures():
+    calls = {"n": 0}
+
+    @U.retry_on_io_error(max_attempts=3, delay=0)
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise IOError("transient")
+        return "ok"
+
+    assert flaky() == "ok"
+    assert calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_retry_reraises_after_exhausting_attempts():
+    calls = {"n": 0}
+
+    @U.retry_on_io_error(max_attempts=2, delay=0)
+    def always_fails():
+        calls["n"] += 1
+        raise IOError("permanent")
+
+    with pytest.raises(IOError):
+        always_fails()
+    assert calls["n"] == 2  # tried exactly max_attempts times
+
+
+def test_retry_does_not_catch_other_exceptions():
+    calls = {"n": 0}
+
+    @U.retry_on_io_error(max_attempts=3, delay=0)
+    def value_error():
+        calls["n"] += 1
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        value_error()
+    assert calls["n"] == 1  # non-IOError propagates immediately, no retry
+
+
+# ---------------------------------------------------------------------------
+# group_ents
+# ---------------------------------------------------------------------------
+
+class _Ent:
+    def __init__(self, g):
+        self.g = g
+
+
+def test_group_ents_groups_consecutive_by_feature():
+    a, b = "a", "b"  # shared objects so identity (`is not`) comparison holds
+    ents = [_Ent(a), _Ent(a), _Ent(b), _Ent(a)]
+    groups = U.group_ents(ents, "g")
+    assert [len(g) for g in groups] == [2, 1, 1]
+    assert [g[0].g for g in groups] == ["a", "b", "a"]
+
+
+def test_group_ents_empty_list():
+    assert U.group_ents([], "g") == []
+
+
+# ---------------------------------------------------------------------------
+# groupby
+# ---------------------------------------------------------------------------
+
+def test_groupby_valid_column():
+    df = pd.DataFrame({"k": ["x", "x", "y"], "v": [1, 2, 3]})
+    g = U.groupby(df, "k")
+    assert sorted(g.groups.keys()) == ["x", "y"]
+    assert g.get_group(("x",))["v"].tolist() == [1, 2]
+
+
+def test_groupby_filters_missing_columns_then_uses_valid_one():
+    df = pd.DataFrame({"k": ["x", "y"], "v": [1, 2]})
+    # only "k" exists; "missing" is dropped by the in-allcols filter
+    g = U.groupby(df, ["missing", "k"])
+    assert sorted(g.groups.keys()) == ["x", "y"]
+
+
+def test_groupby_raises_when_no_valid_columns():
+    df = pd.DataFrame({"k": ["x"], "v": [1]})
+    with pytest.raises(Exception, match="No group"):
+        U.groupby(df, "nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# get_txt
+# ---------------------------------------------------------------------------
+
+def test_get_txt_from_string_strips_whitespace():
+    assert U.get_txt("  hello world  ", None) == "hello world"
+
+
+def test_get_txt_from_file_reads_and_strips():
+    with tempfile.TemporaryDirectory() as d:
+        fn = os.path.join(d, "poem.txt")
+        with open(fn, "w", encoding="utf-8") as f:
+            f.write("  line one\nline two  ")
+        assert U.get_txt(None, fn) == "line one\nline two"
+
+
+def test_get_txt_empty_when_nothing_given():
+    assert U.get_txt(None, None) == ""
+
+
+def test_get_txt_empty_when_file_missing():
+    assert U.get_txt(None, "/no/such/path/xyz.txt") == ""
+
+
+def test_get_txt_from_url_filename(monkeypatch):
+    class FakeResp:
+        text = "  fetched body  "
+
+    monkeypatch.setattr(U.requests, "get", lambda url: FakeResp())
+    assert U.get_txt(None, "http://example.com/poem") == "fetched body"
+
+
+def test_get_txt_string_starting_http_recurses_to_fetch(monkeypatch):
+    class FakeResp:
+        text = "  fetched body  "
+
+    monkeypatch.setattr(U.requests, "get", lambda url: FakeResp())
+    # txt that looks like a URL is treated as one (recurses with fn=txt)
+    assert U.get_txt("http://example.com/poem", None) == "fetched body"
+
+
+# ---------------------------------------------------------------------------
+# get_attr_str
+# ---------------------------------------------------------------------------
+
+def test_get_attr_str_skips_none_values_and_reprs():
+    assert U.get_attr_str({"a": 1, "b": None, "c": "x"}) == "a=1, c='x'"
+
+
+def test_get_attr_str_excludes_bad_keys_and_custom_sep():
+    assert U.get_attr_str({"a": 1, "b": 2}, sep="|", bad_keys=["b"]) == "a=1"
+
+
+# ---------------------------------------------------------------------------
+# safesum
+# ---------------------------------------------------------------------------
+
+def test_safesum_ignores_non_numeric_values():
+    assert U.safesum([1, 2, "x", 3.0, None, np.float64(4.0)]) == 10.0
+
+
+def test_safesum_empty_is_zero():
+    assert U.safesum([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# setindex / niceindex / nicedict
+# ---------------------------------------------------------------------------
+
+def test_setindex_sets_index_and_casts_num_columns_to_int():
+    df = pd.DataFrame(
+        {"line_num": [1.0, 2.0], "line_txt": ["a", "b"], "other": [9, 10]}
+    )
+    out = U.setindex(df, ["line_num", "line_txt"])
+    assert list(out.index.names) == ["line_num", "line_txt"]
+    # _num columns are filled and cast to int
+    assert list(out.index.get_level_values("line_num")) == [1, 2]
+    assert out.index.get_level_values("line_num").dtype.kind == "i"
+
+
+def test_setindex_empty_cols_returns_input():
+    df = pd.DataFrame({"a": [1]})
+    assert U.setindex(df, []).equals(df)
+
+
+def test_setindex_no_matching_cols_returns_unchanged_shape():
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    out = U.setindex(df, ["zzz"])
+    assert out.shape == (1, 2)
+    assert list(out.columns) == ["a", "b"]
+
+
+def test_niceindex_drops_badcols_renames_and_sorts():
+    df = pd.DataFrame(
+        {
+            "wordtoken_line_num": [2, 1],  # renamed to line_num
+            "word_num": [9, 9],            # DF_BADCOLS -> dropped
+            "syll_num": [1, 1],            # index col
+            "is_stressed": [True, False],  # ordinary data col survives
+        }
+    )
+    out = U.niceindex(df)
+    assert "word_num" not in out.columns and "word_num" not in out.index.names
+    assert list(out.index.names) == ["line_num", "syll_num"]
+    assert list(out.columns) == ["is_stressed"]
+    # sorted by index -> line_num ascending
+    assert list(out.index.get_level_values("line_num")) == [1, 2]
+
+
+def test_nicedict_orders_index_keys_first_and_drops_badcols():
+    out = U.nicedict(
+        {"syll_txt": "x", "line_num": 1, "word_txt": "drop", "zzz": 9}
+    )
+    # word_txt is a DF_BADCOL -> dropped; index keys ordered before extras
+    assert list(out.keys()) == ["line_num", "syll_txt", "zzz"]
+    assert "word_txt" not in out
+
+
+# ---------------------------------------------------------------------------
+# format_syll_ipa_str / get_syll_ipa_stress
+# ---------------------------------------------------------------------------
+
+def test_format_syll_ipa_str_empty():
+    assert U.format_syll_ipa_str("") == ""
+
+
+def test_format_syll_ipa_str_primary_stress_normalized_to_leading_mark():
+    # primary "'" wins: strip all marks, prepend a single "'"
+    assert U.format_syll_ipa_str("'kat") == "'kat"
+    assert U.format_syll_ipa_str("'k`at") == "'kat"
+
+
+def test_format_syll_ipa_str_secondary_stress():
+    assert U.format_syll_ipa_str("`kat") == "`kat"
+
+
+def test_format_syll_ipa_str_unstressed_passthrough():
+    assert U.format_syll_ipa_str("kat") == "kat"
+
+
+def test_get_syll_ipa_stress_levels():
+    assert U.get_syll_ipa_stress("") == ""
+    assert U.get_syll_ipa_stress("`ka") == "S"   # secondary mark -> S
+    assert U.get_syll_ipa_stress("'ka") == "P"   # primary mark -> P
+    assert U.get_syll_ipa_stress("ka") == "U"    # none -> U
+
+
+# ---------------------------------------------------------------------------
+# get_initial_whitespace
+# ---------------------------------------------------------------------------
+
+def test_get_initial_whitespace():
+    assert U.get_initial_whitespace("  hi") == "  "
+    assert U.get_initial_whitespace("hi") == ""
+    assert U.get_initial_whitespace("\t\nx") == "\t\n"
+    assert U.get_initial_whitespace("") == ""
+
+
+# ---------------------------------------------------------------------------
+# unique / unique_list / is_listlike
+# ---------------------------------------------------------------------------
+
+def test_unique_preserves_first_seen_order():
+    assert U.unique([3, 1, 3, 2, 1]) == [3, 1, 2]
+
+
+def test_is_listlike_variants():
+    assert U.is_listlike([1, 2]) is True
+    assert U.is_listlike((1, 2)) is True          # tuple has __iter__
+    assert U.is_listlike({"a": 1}) is True         # dict has __iter__
+    assert U.is_listlike("abc") is True            # str has __iter__
+    assert U.is_listlike(x for x in range(3)) is True  # generator
+    assert U.is_listlike(5) is False               # int is not iterable
+    assert U.is_listlike(None) is False
+
+
+def test_unique_list_dedups_preserving_order():
+    assert U.unique_list([1, 1, 2, 3, 2]) == [1, 2, 3]
+
+
+def test_unique_list_non_listlike_returns_empty(caplog):
+    # non-listlike input logs an error and returns []
+    assert U.unique_list(5) == []
+
+
+# ---------------------------------------------------------------------------
+# hashstr
+# ---------------------------------------------------------------------------
+
+def test_hashstr_is_deterministic():
+    assert U.hashstr("a") == U.hashstr("a")
+    assert U.hashstr("a") != U.hashstr("b")
+
+
+def test_hashstr_default_is_full_sha256_hex():
+    h = U.hashstr("anything")
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_hashstr_respects_length_argument():
+    assert len(U.hashstr("a", length=8)) == 8
+
+
+# ---------------------------------------------------------------------------
+# read_json / from_dict / load
+# ---------------------------------------------------------------------------
+
+def test_read_json_roundtrip():
+    with tempfile.TemporaryDirectory() as d:
+        fn = os.path.join(d, "a.json")
+        with open(fn, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"k": 1, "nested": [1, 2]}))
+        assert U.read_json(fn) == {"k": 1, "nested": [1, 2]}
+
+
+def test_read_json_missing_file_returns_empty_dict():
+    assert U.read_json("/no/such/file.json") == {}
+
+
+def test_from_dict_raises_without_class_key():
+    with pytest.raises(Exception):
+        U.from_dict({"no_class_key": 1})
+
+
+@pytest.fixture
+def stub_class():
+    """Register a stub class in GLOBALS so from_dict can dispatch to it."""
+
+    class Stub:
+        @classmethod
+        def from_dict(cls, d, **kw):
+            return ("built", d.get("v"), kw.get("extra"))
+
+    GLOBALS["Stub"] = Stub
+    try:
+        yield Stub
+    finally:
+        GLOBALS.pop("Stub", None)
+
+
+def test_from_dict_dispatches_via_globals(stub_class):
+    result = U.from_dict({"_class": "Stub", "v": 7}, extra="E")
+    assert result == ("built", 7, "E")
+
+
+def test_load_reads_file_then_dispatches(stub_class):
+    with tempfile.TemporaryDirectory() as d:
+        fn = os.path.join(d, "obj.json")
+        with open(fn, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"_class": "Stub", "v": 42}))
+        assert U.load(fn) == ("built", 42, None)
+
+
+# ---------------------------------------------------------------------------
+# ensure_dir
+# ---------------------------------------------------------------------------
+
+def test_ensure_dir_creates_nested_directories():
+    with tempfile.TemporaryDirectory() as d:
+        target = os.path.join(d, "sub", "deep", "file.txt")
+        U.ensure_dir(target)
+        assert os.path.isdir(os.path.join(d, "sub", "deep"))
+
+
+def test_ensure_dir_bare_filename_is_noop():
+    # dirname("file.txt") == "" -> no makedirs, must not raise
+    U.ensure_dir("file.txt")
+
+
+# ---------------------------------------------------------------------------
+# to_html
+# ---------------------------------------------------------------------------
+
+def test_to_html_string_as_str_returns_string():
+    assert U.to_html("<b>hi</b>", as_str=True) == "<b>hi</b>"
+
+
+def test_to_html_string_renders_ipython_object():
+    out = U.to_html("<b>hi</b>", as_str=False)
+    # IPython is installed in this env -> returns an HTML display object
+    assert type(out).__name__ == "HTML"
+    assert out.data == "<b>hi</b>"
+
+
+def test_to_html_delegates_to_object_method():
+    class WithHtml:
+        def to_html(self, as_str=False, **kw):
+            return "STR" if as_str else "OBJ"
+
+    assert U.to_html(WithHtml(), as_str=True) == "STR"
+    assert U.to_html(WithHtml(), as_str=False) == "OBJ"
+
+
+def test_to_html_unknown_type_logs_and_returns_none():
+    assert U.to_html(12345) is None
+
+
+# ---------------------------------------------------------------------------
+# force_int
+# ---------------------------------------------------------------------------
+
+def test_force_int_variants():
+    assert U.force_int("5") == 5
+    assert U.force_int(3.7) == 3
+    assert U.force_int("not a number") == 0
+    assert U.force_int(None) == 0
+    assert U.force_int("bad", errors=-1) == -1
+
+
+# ---------------------------------------------------------------------------
+# tokenize_agnostic
+# ---------------------------------------------------------------------------
+
+def test_tokenize_agnostic_keeps_apostrophe_words_and_splits_punct():
+    assert U.tokenize_agnostic("don't stop, please") == [
+        "don't", " ", "stop", ",", " ", "please"
+    ]
+
+
+def test_tokenize_agnostic_splits_on_hyphen_and_period():
+    assert U.tokenize_agnostic("a-b.") == ["a", "-", "b", "."]
+
+
+# ---------------------------------------------------------------------------
+# clean_text
+# ---------------------------------------------------------------------------
+
+def test_clean_text_replaces_html_entities():
+    assert U.clean_text("Tom &amp; Jerry") == "Tom & Jerry"
+    assert U.clean_text("caf&eacute") == "café"
+    assert U.clean_text("a&mdash;b") == "a -- b"
+
+
+def test_clean_text_ftfy_straightens_curly_quotes():
+    # ftfy.fix_text uncurls quotes to ASCII
+    assert U.clean_text("don’t") == "don't"
+    assert U.clean_text("“x”") == '"x"'
+
+
+def test_clean_text_normalizes_newlines():
+    assert U.clean_text("a\r\nb\rc") == "a\nb\nc"
+
+
+# ---------------------------------------------------------------------------
+# eprint
+# ---------------------------------------------------------------------------
+
+def test_eprint_writes_to_stderr(capsys):
+    U.eprint("hello", "there")
+    captured = capsys.readouterr()
+    assert captured.err == "hello there\n"
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# caching / logging no-op flags and context managers
+# ---------------------------------------------------------------------------
+
+def test_caching_is_always_disabled():
+    assert U.caching_is_enabled() is False
+    # the enable/disable functions are no-ops that must not raise
+    U.enable_caching()
+    U.disable_caching()
+    assert U.caching_is_enabled() is False
+
+
+def test_caching_context_managers_are_noops():
+    with U.caching_enabled():
+        assert U.caching_is_enabled() is False
+    with U.caching_disabled():
+        assert U.caching_is_enabled() is False
+    # still disabled afterwards
+    assert U.caching_is_enabled() is False
+
+
+def test_logging_disabled_toggles_and_restores():
+    before = logmap.is_quiet
+    with U.logging_disabled():
+        assert logmap.is_quiet is True
+    assert logmap.is_quiet == before
+
+
+def test_logging_enabled_toggles_and_restores():
+    before = logmap.is_quiet
+    with U.logging_enabled():
+        assert logmap.is_quiet is False
+    assert logmap.is_quiet == before

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -458,3 +458,676 @@ def test_stanza_missing_returns_clean_400(client, monkeypatch):
         syntax=True, syntax_model='stanza'))
     assert resp.status_code == 400
     assert 'stanza' in resp.json()['detail'].lower()
+
+
+# ============================================================================
+# Coverage expansion for prosodic/web/api.py: endpoints + branches that the
+# suite above didn't reach. Uses the module-scoped `client` fixture defined at
+# the top of this file (FastAPI TestClient over prosodic.web.api.app).
+# ============================================================================
+
+# canonical iambic pentameter — stable scansion, used as a concrete oracle
+_PENTAMETER = 'Shall I compare thee to a summers day'
+_PENTAMETER2 = 'Thou art more lovely and more temperate'
+# a single line that exceeds MAX_SYLL_IN_PARSE_UNIT (18) canonical syllables,
+# with commas so it splits into short, parseable lineparts (prose fallback).
+_PROSE_LINE = ('the cat sat on the mat, and the dog ran in the fog, '
+               'while a bird flew over the far third hill')
+
+
+# -- /api/parse/export : CSV / TSV / JSON download --------------------------
+
+def test_export_csv(client):
+    import csv
+    import io
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=f'{_PENTAMETER}\n{_PENTAMETER2}', format='csv'))
+    assert resp.status_code == 200
+    assert resp.headers['content-type'].startswith('text/csv')
+    assert resp.headers['content-disposition'] == \
+        'attachment; filename="prosodic-parse.csv"'
+    rows = list(csv.DictReader(io.StringIO(resp.text)))
+    assert len(rows) == 2  # one export row per line
+    r0 = rows[0]
+    # required stat columns present
+    for col in ('line_num', 'line_text', 'meter_str', 'num_sylls', 'num_viols',
+                'num_parses', 'score', 'score_unbounded', 'num_sylls_unbounded'):
+        assert col in r0, col
+    assert r0['line_num'] == '1'
+    assert r0['meter_str'] == '-+-+-+-+-+'   # iambic pentameter
+    assert r0['num_sylls'] == '10'
+    # unbounded sum >= best-parse score (sum over >=1 parses)
+    assert float(r0['score_unbounded']) >= float(r0['score'])
+
+
+def test_export_tsv(client):
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=_PENTAMETER, format='tsv'))
+    assert resp.status_code == 200
+    assert 'tab-separated-values' in resp.headers['content-type']
+    assert resp.headers['content-disposition'].endswith('prosodic-parse.tsv"')
+    header = resp.text.splitlines()[0]
+    assert '\t' in header and ',' not in header.split('\t')[0]
+    assert 'meter_str' in header.split('\t')
+
+
+def test_export_json(client):
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=f'{_PENTAMETER}\n{_PENTAMETER2}', format='json'))
+    assert resp.status_code == 200
+    assert resp.headers['content-type'].startswith('application/json')
+    assert resp.headers['content-disposition'].endswith('prosodic-parse.json"')
+    data = json.loads(resp.text)
+    assert isinstance(data, list) and len(data) == 2
+    assert data[0]['meter_str'] == '-+-+-+-+-+'
+    assert data[0]['num_sylls'] == 10
+    # per-constraint violation columns are emitted with a '*' prefix
+    assert any(k.startswith('*') for k in data[0])
+
+
+def test_export_default_format_is_csv(client):
+    # format omitted -> defaults to csv (req.get('format') or 'csv')
+    resp = client.post('/api/parse/export', json=_default_parse_data(text=_PENTAMETER))
+    assert resp.status_code == 200
+    assert resp.headers['content-type'].startswith('text/csv')
+
+
+def test_export_bad_format_400(client):
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=_PENTAMETER, format='xml'))
+    assert resp.status_code == 400
+    assert 'csv' in resp.json()['detail'].lower()
+
+
+def test_export_no_text_400(client):
+    resp = client.post('/api/parse/export', json=_default_parse_data(text='   '))
+    assert resp.status_code == 400
+
+
+def test_export_prose_meter_pipe_separated(client):
+    # A prose (long) line exports best-only, with lineparts joined by ' | '
+    # in meter_str (the <br> the HTML view uses is rewritten for flat export).
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=_PROSE_LINE, format='json'))
+    assert resp.status_code == 200
+    data = json.loads(resp.text)
+    assert len(data) == 1
+    assert ' | ' in data[0]['meter_str']
+    assert data[0]['num_parses'] >= 1
+
+
+# -- /api/parse prose fallback (long line -> linepart parsing) ---------------
+
+def test_parse_prose_fallback_lineparts(client):
+    resp = client.post('/api/parse', json=_default_parse_data(text=_PROSE_LINE))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['prose_mode'] is True
+    assert data['num_lines'] == 1
+    row = data['rows'][0]
+    # multiple lineparts, all parsed; parse + meter strings break on <br>
+    assert row['num_parts'] >= 3
+    assert row['num_parts_parsed'] == row['num_parts']
+    assert '<br>' in row['meter_str']
+    assert '<br>' in row['parse_html']
+    assert 'mtr_s' in row['parse_html']
+
+
+def test_parse_prose_single_overlong_linepart_unparsed(client):
+    # A long line with NO punctuation is a single linepart still over the cap:
+    # it can't be parsed and renders as an <span class="unparsed"> clause with
+    # an em-dash meter marker.
+    text = ('one two three four five six seven eight nine ten eleven twelve '
+            'more words here to push this well over the syllable cap now')
+    resp = client.post('/api/parse', json=_default_parse_data(text=text))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['prose_mode'] is True
+    row = data['rows'][0]
+    assert row['num_parts_parsed'] == 0
+    assert 'unparsed' in row['parse_html']
+    assert '—' in row['meter_str']
+
+
+def test_parse_prose_syntax_subsplit(client):
+    # syntax=True lets an over-cap, punctuation-free clause be sub-split at
+    # dependency clause boundaries (cc/advcl/relcl...) via _syntax_subsplit.
+    pytest.importorskip("spacy")
+    text = ('the hungry cat sat on the mat and the lazy dog ran through the '
+            'field while a bird flew away')
+    try:
+        resp = client.post('/api/parse', json=_default_parse_data(text=text, syntax=True))
+    except OSError:
+        pytest.skip("spaCy model not installed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['prose_mode'] is True
+    row = data['rows'][0]
+    # sub-split produced multiple parseable clauses (more than the 1 raw linepart)
+    assert row['num_parts'] >= 2
+    assert row['num_parts_parsed'] >= 2
+
+
+# -- /api/parse zone-weighted scoring ---------------------------------------
+
+def test_parse_with_zone_weights(client):
+    # Fit to obtain zone-expanded weights, then feed them back to /api/parse:
+    # exercises the zone_weights branch and the _scores (has_zone) scoring path.
+    text = f'{_PENTAMETER}\n{_PENTAMETER2}'
+    cons = ['w_stress', 's_unstress', 'w_peak']
+    fit = client.post('/api/maxent/fit', json={
+        'text': text, 'target_scansion': 'wswswswsws', 'zones': 3,
+        'regularization': 100, 'constraints': cons, 'max_s': 2, 'max_w': 2,
+    }).json()
+    zw = {w['name']: w['weight'] for w in fit['weights']}
+    assert zw  # fit produced some weights
+    resp = client.post('/api/parse', json=_default_parse_data(
+        text=text, constraints=cons, zone_weights=zw, zones=3))
+    assert resp.status_code == 200
+    rows = resp.json()['rows']
+    assert len(rows) >= 2
+    assert all(isinstance(r['score'], (int, float)) for r in rows)
+
+
+# -- /api/parse/stream : successful SSE run ----------------------------------
+
+def _parse_sse(body):
+    """Return the list of decoded data payloads from an SSE response body."""
+    out = []
+    for line in body.splitlines():
+        if line.startswith('data: '):
+            out.append(json.loads(line[len('data: '):]))
+    return out
+
+
+def test_parse_stream_success_phases(client):
+    resp = client.post('/api/parse/stream', json=_default_parse_data(
+        text=f'{_PENTAMETER}\n{_PENTAMETER2}'))
+    assert resp.status_code == 200
+    assert resp.headers['content-type'].startswith('text/event-stream')
+    events = _parse_sse(resp.text)
+    phases = [e['phase'] for e in events]
+    assert phases[0] == 'progress'
+    assert 'rows' in phases
+    assert phases[-1] == 'done'
+    # the 'rows' event carries server-rendered parse HTML
+    rows_ev = next(e for e in events if e['phase'] == 'rows')
+    assert rows_ev['rows']
+    assert any('mtr_' in r['parse_html'] for r in rows_ev['rows'])
+    # the terminal 'done' event summarizes the run
+    done = events[-1]
+    assert done['num_lines'] == 2
+    assert done['prose_mode'] is False
+    assert 'w_stress' in done['constraints']
+
+
+def test_parse_stream_no_text_400(client):
+    resp = client.post('/api/parse/stream', json=_default_parse_data(text='   '))
+    assert resp.status_code == 400
+
+
+def test_parse_stream_oversized_413(client):
+    from prosodic.web.api import MAX_INPUT_CHARS
+    resp = client.post('/api/parse/stream', json={'text': 'a ' * (MAX_INPUT_CHARS // 2 + 50)})
+    assert resp.status_code == 413
+
+
+# -- /api/parse/line : prose (multi-part) + error branches -------------------
+
+def test_parse_line_prose_parts(client):
+    resp = client.post('/api/parse/line', json=_default_parse_data(text=_PROSE_LINE))
+    assert resp.status_code == 200
+    data = resp.json()
+    # long line -> top-level parses empty, per-linepart detail in `parts`
+    assert data['parses'] == []
+    assert len(data['parts']) >= 3
+    part = data['parts'][0]
+    assert set(part) >= {'part_text', 'num_sylls', 'parses', 'num_parses', 'num_unbounded'}
+    assert part['num_parses'] == len(part['parses'])
+    assert data['num_parses'] == sum(p['num_parses'] for p in data['parts'])
+    # every part parse still carries a grid
+    assert all(p['grid'] for p in part['parses'])
+
+
+def test_parse_line_no_text_400(client):
+    resp = client.post('/api/parse/line', json=_default_parse_data(text='   '))
+    assert resp.status_code == 400
+
+
+def test_parse_line_oversized_413(client):
+    from prosodic.web.api import MAX_INPUT_CHARS
+    resp = client.post('/api/parse/line', json={'text': 'a ' * (MAX_INPUT_CHARS // 2 + 50)})
+    assert resp.status_code == 413
+
+
+def test_parse_oversized_413(client):
+    from prosodic.web.api import MAX_INPUT_CHARS
+    resp = client.post('/api/parse', json={'text': 'a ' * (MAX_INPUT_CHARS // 2 + 50)})
+    assert resp.status_code == 413
+    assert 'too large' in resp.json()['detail'].lower()
+
+
+# -- /api/maxent/reparse -----------------------------------------------------
+
+def test_maxent_reparse(client):
+    resp = client.post('/api/maxent/reparse', json={
+        'text': 'From fairest creatures we desire increase\n'
+                'That thereby beautys rose might never die',
+        'target_scansion': 'wswswswsws', 'zones': 3, 'regularization': 100,
+        'constraints': ['w_stress', 's_unstress', 'w_peak'], 'max_s': 2, 'max_w': 2,
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'elapsed' in data
+    assert len(data['rows']) == 2
+    r0 = data['rows'][0]
+    assert set(r0) == {'line_num', 'line_txt', 'meter_str', 'score'}
+    assert r0['line_num'] == 1
+    assert set(r0['meter_str']) <= {'+', '-'}
+
+
+def test_maxent_reparse_no_text_400(client):
+    resp = client.post('/api/maxent/reparse', json={'text': '  '})
+    assert resp.status_code == 400
+
+
+# -- /api/maxent/fit-annotations (file upload) -------------------------------
+
+def _anno_tsv(header_rows):
+    return ''.join(header_rows)
+
+
+def test_maxent_fit_annotations_tsv(client):
+    tsv = ('text\tscansion\tfrequency\n'
+           'From fairest creatures we desire increase\twswswswsws\t1\n'
+           'That thereby beautys rose might never die\twswswswsws\t1\n')
+    resp = client.post(
+        '/api/maxent/fit-annotations',
+        files={'annotations_file': ('anno.tsv', tsv, 'text/tab-separated-values')},
+        data={'constraints': 'w_stress,s_unstress,w_peak', 'zones': '3',
+              'regularization': '100'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['config']['target'] == '(from annotations)'
+    assert data['config']['zones'] == '3'
+    assert isinstance(data['weights'], list)
+    assert isinstance(data['accuracy'], float)
+    assert 0 <= data['accuracy'] <= 1
+    assert data['num_lines'] >= 1
+
+
+def test_maxent_fit_annotations_zones_none(client):
+    # zones='none' -> _normalize_zones -> None -> flat weighted training
+    tsv = ('text\tscansion\n'
+           'From fairest creatures we desire increase\twswswswsws\n'
+           'That thereby beautys rose might never die\twswswswsws\n')
+    resp = client.post(
+        '/api/maxent/fit-annotations',
+        files={'annotations_file': ('anno.tsv', tsv, 'text/tsv')},
+        data={'zones': 'none'})
+    assert resp.status_code == 200
+    assert resp.json()['config']['zones'] == 'none'
+
+
+def test_maxent_fit_annotations_missing_text_column_400(client):
+    # No column resembling text/line -> can't map a text column.
+    tsv = 'foo\tscan\nhello world\twsws\n'
+    resp = client.post(
+        '/api/maxent/fit-annotations',
+        files={'annotations_file': ('a.tsv', tsv, 'text/tsv')}, data={})
+    assert resp.status_code == 400
+    assert 'text column' in resp.json()['detail'].lower()
+
+
+def test_maxent_fit_annotations_missing_scansion_column_400(client):
+    # Literal `text` column present (skips mapping), but no scansion column.
+    tsv = 'text\tfoo\nhello world\tbar\n'
+    resp = client.post(
+        '/api/maxent/fit-annotations',
+        files={'annotations_file': ('a.tsv', tsv, 'text/tsv')}, data={})
+    assert resp.status_code == 400
+    assert 'scansion column' in resp.json()['detail'].lower()
+
+
+def test_maxent_fit_annotations_fuzzy_columns(client):
+    # Non-canonical headers (line/parse/count) are auto-detected and remapped to
+    # text/scansion/frequency (col_map is {old: new}; see fit-annotations).
+    tsv = ('line\tparse\tcount\n'
+           'From fairest creatures we desire increase\twswswswsws\t2\n'
+           'That thereby beautys rose might never die\twswswswsws\t1\n')
+    resp = client.post(
+        '/api/maxent/fit-annotations',
+        files={'annotations_file': ('a.tsv', tsv, 'text/tsv')}, data={'zones': 'none'})
+    assert resp.status_code == 200
+    assert 'weights' in resp.json()
+
+
+def test_maxent_fit_annotations_syntax(client):
+    # syntax=True builds a syntax-enabled TextModel and threads it through fit.
+    pytest.importorskip("spacy")
+    tsv = ('text\tscansion\n'
+           'From fairest creatures we desire increase\twswswswsws\n'
+           'That thereby beautys rose might never die\twswswswsws\n')
+    try:
+        resp = client.post(
+            '/api/maxent/fit-annotations',
+            files={'annotations_file': ('a.tsv', tsv, 'text/tsv')},
+            data={'syntax': 'true', 'zones': '3'})
+    except OSError:
+        pytest.skip("spaCy model not installed")
+    assert resp.status_code == 200
+    assert resp.json()['config']['target'] == '(from annotations)'
+
+
+# -- /api/corpora/read -------------------------------------------------------
+
+def test_read_corpus_ok(client):
+    listing = client.get('/api/corpora').json()['files']
+    target = next(f for f in listing if f['name'] == 'en.shakespeare.txt')
+    resp = client.get('/api/corpora/read', params={'path': target['path']})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['name'] == 'en.shakespeare.txt'
+    assert 'Shall I compare' in data['text'] or len(data['text']) > 1000
+
+
+def test_read_corpus_path_traversal_rejected(client):
+    resp = client.get('/api/corpora/read', params={'path': '../../etc/passwd'})
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'Invalid path'
+
+
+def test_read_corpus_not_found(client):
+    resp = client.get('/api/corpora/read',
+                      params={'path': 'corppoetry_en/does-not-exist.txt'})
+    assert resp.status_code == 404
+
+
+def test_corpora_list_counts_lines(client):
+    # num_lines is a positive count of non-blank lines (glob + read branch).
+    files = client.get('/api/corpora').json()['files']
+    sh = next(f for f in files if f['name'] == 'en.shakespeare.txt')
+    assert sh['num_lines'] > 100
+    assert sh['lang'] == 'en'
+
+
+# -- /api/parse/lp error / unavailable branches ------------------------------
+
+def test_parse_lp_no_text_400(client):
+    resp = client.post('/api/parse/lp', json={'text': '   '})
+    assert resp.status_code == 400
+
+
+def test_parse_lp_unavailable_on_exception(client, monkeypatch):
+    # lp_line_data raising -> {available: False, reason: <msg>} (not a 500).
+    import prosodic.analysis.metrical_lp as M
+
+    def _boom(_line):
+        raise RuntimeError("no constituency backend")
+
+    monkeypatch.setattr(M, "lp_line_data", _boom)
+    resp = client.post('/api/parse/lp', json={'text': 'thirteen men'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['available'] is False
+    assert 'no constituency backend' in data['reason']
+
+
+def test_parse_lp_unavailable_on_none(client, monkeypatch):
+    # lp_line_data returning None -> {available: False, reason: 'no parse'}.
+    import prosodic.analysis.metrical_lp as M
+    monkeypatch.setattr(M, "lp_line_data", lambda _line: None)
+    resp = client.post('/api/parse/lp', json={'text': 'thirteen men'})
+    assert resp.status_code == 200
+    assert resp.json() == {'available': False, 'reason': 'no parse',
+                           'line_text': None} or resp.json()['available'] is False
+
+
+# -- Helper-level branch coverage -------------------------------------------
+
+def test_normalize_zones():
+    from prosodic.web.api import _normalize_zones
+    assert _normalize_zones(None) is None
+    assert _normalize_zones("none") is None
+    assert _normalize_zones("3") == 3 and isinstance(_normalize_zones("3"), int)
+    assert _normalize_zones(3) == 3
+    assert _normalize_zones("foot") == "foot"   # non-digit string passes through
+
+
+def test_clamp_timeout():
+    from prosodic.web.api import (_clamp_timeout, PARSE_TIMEOUT_DEFAULT,
+                                  PARSE_TIMEOUT_MAX)
+    assert _clamp_timeout({}) == PARSE_TIMEOUT_DEFAULT           # missing
+    assert _clamp_timeout({'parse_timeout': 'abc'}) == PARSE_TIMEOUT_DEFAULT  # unparsable
+    assert _clamp_timeout({'parse_timeout': -5}) == PARSE_TIMEOUT_DEFAULT     # <= 0
+    assert _clamp_timeout({'parse_timeout': 99999}) == PARSE_TIMEOUT_MAX      # capped
+    assert _clamp_timeout({'parse_timeout': 12}) == 12.0                      # normal
+
+
+def test_permalink_to_req_non_dict():
+    from fastapi import HTTPException
+    from prosodic.web.api import _permalink_to_req
+    with pytest.raises(HTTPException) as ei:
+        _permalink_to_req(['not', 'a', 'dict'])
+    assert ei.value.status_code == 400
+
+
+def test_permalink_to_req_weight_folding():
+    from prosodic.web.api import _permalink_to_req
+    req = _permalink_to_req({
+        'text': 'hi',
+        'meter': {'constraints': ['w_stress', 'w_peak'], 'max_s': 2, 'max_w': 2},
+        'weights': {'w_stress': 2.5, 'w_peak': 1.0},   # 1.0 not folded
+        'parse_timeout': 7,
+    })
+    assert req['constraints'] == ['w_stress/2.5', 'w_peak']
+    assert req['parse_timeout'] == 7
+
+
+def test_permalink_to_req_zone_weights():
+    from prosodic.web.api import _permalink_to_req
+    req = _permalink_to_req({
+        'text': 'hi',
+        'meter': {'constraints': ['w_stress']},
+        'weights': {'w_stress': 2.0},
+        'zoneWeights': {'w_stress_z1': 1.0},
+        'zones': 2,
+    })
+    # zoneWeights present -> weights are NOT folded into constraints
+    assert req['constraints'] == ['w_stress']
+    assert req['zone_weights'] == {'w_stress_z1': 1.0}
+    assert req['zones'] == 2
+
+
+def test_decode_permalink_empty():
+    from fastapi import HTTPException
+    from prosodic.web.api import _decode_permalink
+    with pytest.raises(HTTPException) as ei:
+        _decode_permalink('')
+    assert ei.value.status_code == 400
+
+
+def test_decode_permalink_bad_json():
+    import base64
+    from fastapi import HTTPException
+    from prosodic.web.api import _decode_permalink
+    bad = base64.urlsafe_b64encode(b'not json at all {{{').decode('ascii').rstrip('=')
+    with pytest.raises(HTTPException) as ei:
+        _decode_permalink(bad)
+    assert ei.value.status_code == 400
+
+
+def test_render_parse_html_no_line_fallback():
+    # render_parse_html(parse) with no line falls back to space-joining slots.
+    from prosodic.web.api import render_parse_html
+    from prosodic.parsing.vectorized import parse_batch
+    from prosodic.parsing.meter import Meter
+    from prosodic.imports import TextModel
+    t = TextModel('To be or not to be')
+    _wt, pl = parse_batch(t.lines, Meter())[0]
+    html_out = render_parse_html(pl.best_parse)   # no `line` argument
+    assert 'mtr_s' in html_out and 'mtr_w' in html_out
+    assert '<span' in html_out
+
+
+def test_decode_permalink_bad_gzip():
+    # gzip magic bytes but a corrupt body -> "Invalid permalink compression" 400.
+    import base64
+    from fastapi import HTTPException
+    from prosodic.web.api import _decode_permalink
+    data = base64.urlsafe_b64encode(b'\x1f\x8b' + b'\x00' * 20).decode('ascii').rstrip('=')
+    with pytest.raises(HTTPException) as ei:
+        _decode_permalink(data)
+    assert ei.value.status_code == 400
+
+
+# -- /api/parse/stream : batching + prose progress ---------------------------
+
+def test_parse_stream_batches_over_fifty(client):
+    # >50 result rows are flushed in multiple 'rows' events (BATCH_SIZE=50).
+    text = '\n'.join([_PENTAMETER] * 60)
+    resp = client.post('/api/parse/stream', json=_default_parse_data(text=text))
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    rows_events = [e for e in events if e['phase'] == 'rows']
+    assert len(rows_events) >= 2                       # more than one batch
+    assert all(len(e['rows']) <= 50 for e in rows_events)
+    total = sum(len(e['rows']) for e in rows_events)
+    assert total > 50
+    assert events[-1]['phase'] == 'done'
+    assert events[-1]['num_lines'] == 60
+
+
+def test_parse_stream_prose_progress(client):
+    # A long line makes the stream emit a "long line(s) detected" progress event.
+    resp = client.post('/api/parse/stream', json=_default_parse_data(text=_PROSE_LINE))
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    msgs = [e.get('message', '') for e in events if e['phase'] == 'progress']
+    assert any('long line' in m for m in msgs)
+    assert events[-1]['phase'] == 'done'
+    assert events[-1]['prose_mode'] is True
+
+
+def test_parse_stream_with_zone_weights(client):
+    text = f'{_PENTAMETER}\n{_PENTAMETER2}'
+    cons = ['w_stress', 's_unstress', 'w_peak']
+    fit = client.post('/api/maxent/fit', json={
+        'text': text, 'target_scansion': 'wswswswsws', 'zones': 3,
+        'regularization': 100, 'constraints': cons, 'max_s': 2, 'max_w': 2,
+    }).json()
+    zw = {w['name']: w['weight'] for w in fit['weights']}
+    resp = client.post('/api/parse/stream', json=_default_parse_data(
+        text=text, constraints=cons, zone_weights=zw, zones=3))
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    assert events[-1]['phase'] == 'done'
+    assert any(e['phase'] == 'rows' for e in events)
+
+
+# -- zone-weighted export + line detail --------------------------------------
+
+def test_export_with_zone_weights(client):
+    text = f'{_PENTAMETER}\n{_PENTAMETER2}'
+    cons = ['w_stress', 's_unstress', 'w_peak']
+    fit = client.post('/api/maxent/fit', json={
+        'text': text, 'target_scansion': 'wswswswsws', 'zones': 3,
+        'regularization': 100, 'constraints': cons, 'max_s': 2, 'max_w': 2,
+    }).json()
+    zw = {w['name']: w['weight'] for w in fit['weights']}
+    resp = client.post('/api/parse/export', json=_default_parse_data(
+        text=text, format='json', constraints=cons, zone_weights=zw, zones=3))
+    assert resp.status_code == 200
+    data = json.loads(resp.text)
+    assert len(data) == 2
+    assert all('score_unbounded' in r for r in data)
+
+
+def test_parse_line_with_zone_weights(client):
+    text = _PENTAMETER
+    cons = ['w_stress', 's_unstress', 'w_peak']
+    fit = client.post('/api/maxent/fit', json={
+        'text': f'{_PENTAMETER}\n{_PENTAMETER2}', 'target_scansion': 'wswswswsws',
+        'zones': 3, 'regularization': 100, 'constraints': cons, 'max_s': 2, 'max_w': 2,
+    }).json()
+    zw = {w['name']: w['weight'] for w in fit['weights']}
+    resp = client.post('/api/parse/line', json=_default_parse_data(
+        text=text, constraints=cons, zone_weights=zw, zones=3))
+    assert resp.status_code == 200
+    parses = resp.json()['parses']
+    assert parses
+    assert all(isinstance(p['score'], (int, float)) for p in parses)
+
+
+def test_parse_line_syntax_prose_subsplit(client):
+    # Line View on an over-cap, punctuation-free clause with syntax=True routes
+    # through the multi-part branch + _syntax_subsplit, returning per-part detail.
+    pytest.importorskip("spacy")
+    text = ('the hungry cat sat on the mat and the lazy dog ran through the '
+            'field while a bird flew away')
+    try:
+        resp = client.post('/api/parse/line', json=_default_parse_data(text=text, syntax=True))
+    except OSError:
+        pytest.skip("spaCy model not installed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['parses'] == []
+    assert len(data['parts']) >= 2
+
+
+# -- main() launcher entrypoint (uvicorn mocked) -----------------------------
+
+def test_main_invokes_uvicorn(monkeypatch):
+    # main() should resolve default host/port and hand app to uvicorn.run.
+    import uvicorn
+    called = {}
+    monkeypatch.setattr(uvicorn, 'run',
+                        lambda app, **kw: called.update(host=kw.get('host'),
+                                                        port=kw.get('port')))
+    from prosodic.web.api import main
+    main(debug=False)   # debug=False skips logmap.enable(); dev=False default
+    assert called['host'] == '127.0.0.1'
+    assert called['port'] == 8181
+
+
+def test_main_debug_enables_logmap(monkeypatch):
+    import uvicorn
+    import prosodic.web.api as api
+    seen = {}
+    monkeypatch.setattr(uvicorn, 'run', lambda app, **kw: seen.update(kw))
+    monkeypatch.setattr(api.logmap, 'enable', lambda: seen.update(logmap=True))
+    api.main(debug=True, port=4321)
+    assert seen.get('logmap') is True
+    assert seen['port'] == 4321
+
+
+def test_main_dev_delegates_to_run_dev(monkeypatch):
+    import prosodic.web.api as api
+    seen = {}
+    monkeypatch.setattr(api, '_run_dev', lambda **kw: seen.update(kw))
+    api.main(dev=True, port=1234, host='0.0.0.0', debug=False)
+    assert seen == {'host': '0.0.0.0', 'port': 1234, 'debug': False}
+
+
+def test_parse_stream_surfaces_mid_stream_error(client, monkeypatch):
+    # A non-timeout failure during parsing is surfaced as an SSE 'error' event
+    # (not a crash / silent hang). W8 in the source.
+    import prosodic.web.api as api
+
+    def _boom(t, meter):
+        raise ValueError("synthetic parse failure")
+
+    monkeypatch.setattr(api, '_parse_and_build_rows', _boom)
+    resp = client.post('/api/parse/stream', json=_default_parse_data(text=_PENTAMETER))
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    err = [e for e in events if e['phase'] == 'error']
+    assert err and 'synthetic parse failure' in err[0]['message']
+
+
+def test_get_text_cache_is_bounded():
+    # The TextModel LRU cache evicts once it exceeds _TEXT_CACHE_MAX (line 126).
+    from prosodic.web.api import get_text, _text_cache, _TEXT_CACHE_MAX
+    for i in range(_TEXT_CACHE_MAX + 5):
+        get_text(f'unique cache probe line number {i} alpha')
+    assert len(_text_cache) <= _TEXT_CACHE_MAX


### PR DESCRIPTION
Gets prosodic's test coverage over 90%.

## How
- **Exclude vendored `prosodic/lib/`** (panphon, metricaltree, syllabiphon — third-party, not our code) from coverage via `[tool.coverage.run] omit`. This alone: **80% → 84%** (that vendored code was 30% of all "misses").
- **+157 meaningful tests** across the four biggest real gaps:
  - `web/api.py` **50% → 93%** (+53 TestClient tests: export CSV/TSV/JSON, SSE stream, maxent reparse/fit-annotations, /parse/line detail, corpora, prose fallback, permalink, error branches)
  - `utils.py` **53% → 99%**, `ents.py` **82% → 96%**, `langs.py` **84% → 96%**

## Bug fixed
`/api/maxent/fit-annotations` fuzzy column mapping was **inverted** — `col_map[new]=old` then `df.rename(columns=col_map)` (which wants `{old:new}`) was a no-op, so any upload with `line`/`parse`/`count` headers hit a `KeyError` 500 instead of auto-detecting. Now `col_map[old]=new`; test un-xfailed.

## Latent bugs found & noted (not fixed here — dead code)
- `Entity.wordform_matrix` infinitely recurses (no callers).
- Dead-code dups: `langs.py` `sylls_ipa_l_has_stress` (defined twice), `ents.py` shadowed `meter` property.

**Total: 91%** (8930 stmts, 794 missed). **675 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)