### PR TITLE
Dominated-length reference readings show their own best pronunciation

### DIFF
--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -82,7 +82,7 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
     if not pool_unb:
         return get_lpl(0)
 
-    def build_for_N(N, full_ok=True):
+    def build_for_N(N, full_ok=True, full_forms=False):
         """Pooled LazyParseList over the combos whose scansions have N syllables
         (they share a scansion space): combo-base + overlay, exactly as the
         single-N path. `pool_unb` already reflects cross-N domination. `full_ok`
@@ -90,7 +90,17 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
         set); the mixed-N caller passes full_ok=False so every length goes through
         the same dedup-by-meter-string overlay, keeping the ragged list's
         per-length representation symmetric (bounded reporting / sylls_by_scansion
-        set on every length, not just the overlaid ones)."""
+        set on every length, not just the overlaid ones).
+
+        `full_forms=True` (passed for DOMINATED lengths only): also overlay
+        cross-N-BOUNDED parses, so each meter string gets its within-length
+        MIN-SCORE pronunciation rather than only the base (canonical) combo's forms.
+        Without it, a dominated length (no unbounded members) shows every function
+        word at its default form — e.g. the 10-syll `(ws)×5` of "Thou art…" reports
+        `art` unstressed (a spurious extra `s_unstress`) even though promoting it
+        (a form the lexicon has) is that reading's own optimum. The sort key keeps
+        unbounded < bounded then min-score, so surviving lengths are unaffected and
+        num_parses / best_parse never move (dominated lengths stay all-bounded)."""
         group = sorted(r for r in range(len(candidates)) if N_of[r] == N)
         base = group[0]
         pool_unb_N = {(r, i) for (r, i) in pool_unb if N_of[r] == N}
@@ -107,11 +117,12 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
         for rank in group[1:]:
             for i in np.where(candidates[rank][1])[0]:
                 i = int(i)
-                if (rank, i) not in pool_unb:
-                    continue
+                bounded = (rank, i) not in pool_unb
+                if bounded and not full_forms:
+                    continue                           # surviving length: unbounded overlay only
                 lr = get_lpl(rank)
                 ms = _pool_meter_str(lr, i)
-                sk = (False, float(lr._all_scores[i]), rank, i)
+                sk = (bounded, float(lr._all_scores[i]), rank, i)
                 cur = best_rep.get(ms)
                 if cur is None or sk < cur[0]:
                     best_rep[ms] = (sk, rank, i)
@@ -153,8 +164,12 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
     # all-bounded (build_for_N marks them so, since none are in pool_unb). Cross-length
     # domination is already in pool_unb, so each sub-list's mask is correct.
     scans, viols, mv, pi, ps, sylls_by, rowidx_by, unb = [], [], [], [], [], [], [], []
+    extra_set = set(extra_Ns)
     for N in list(surv_Ns) + extra_Ns:
-        sub = build_for_N(N, full_ok=False)
+        # dominated lengths get full_forms=True so their reference readings show each
+        # meter's own best pronunciation (promotable function words promoted), not the
+        # canonical-only base combo. Surviving lengths keep the fast unbounded overlay.
+        sub = build_for_N(N, full_ok=False, full_forms=(N in extra_set))
         sbs, rbs = sub._sylls_by_scansion, sub._syll_row_idx_by_scansion
         for i in range(len(sub._all_scansions)):
             scans.append(sub._all_scansions[i])

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -420,6 +420,27 @@ def test_line_best_parse_matches_text_parse():
             f"line {ln.num} num_words: line-path {bp.num_words} != text.parse {nw}"
 
 
+def test_dominated_length_shows_best_pronunciation():
+    """A FULLY-dominated syllable length (every parse cross-bounded by a shorter
+    reading) is kept as a bounded reference row; it must show each meter's OWN best
+    pronunciation, not just the canonical base combo. Regression: the 10-syllable
+    (ws×5) reading of "Thou art more lovely and more temperate" — dominated by the
+    9-syllable elided winner — used to freeze every function word at its default form,
+    so `art` printed unstressed (a spurious 3rd s_unstress, score 3). It should promote
+    `art` (a stressed form the lexicon has), scoring 2 (only `and` + `ate`), consistent
+    with how the winning length is treated. best_parse / num_parses are unaffected."""
+    t = TextModel("Thou art more lovely and more temperate")
+    line = t.lines[0]
+    assert line.best_parse.meter_str == "-+-+-+-+-"          # 9-syll winner unchanged
+    ws5 = [p for p in list(line.parses.unbounded) + list(line.parses.bounded)
+           if p.meter_str == "-+-+-+-+-+"]
+    assert ws5, "the 10-syllable (ws×5) reading should appear as a bounded reference row"
+    p = ws5[0]
+    stresses = [bool(slot.unit.is_stressed) for pos in p.positions for slot in pos.children]
+    assert stresses[1], "art (2nd syllable) must be promoted in the dominated ws×5 reading"
+    assert p.score == 2.0, "with art promoted, only `and` + `ate` violate (not a 3rd on art)"
+
+
 def test_pool_forms_pools_pronunciation_variants():
     """pool_forms=True (default) reports scansions optimal under ANY pronunciation
     of an ambiguous word — Prosodic's in-situ variant resolution — not just the


### PR DESCRIPTION
## Dominated-length reference readings now show their own best pronunciation

**The symptom** (spotted on prosodic.app 3.9.0, Line View for *"Thou art more lovely and more temperate"*): the 10-syllable `(ws)×5` reading — trisyllabic "tem-per-ate", the canonical iambic scansion — was shown at **score 3** with `art`, `and`, *and* `ate` all unstressed on strong beats. But `art` is a function word with a stressed variant (it's promoted in the 9-syllable winner), so the true `(ws)×5` optimum is **score 2** (`art` promoted; only `and` + `ate` violate).

**Root cause.** A fully-dominated syllable length (every parse cross-bounded by a shorter reading — here the 9-syllable elided winner, `{s_unstress:1}`, dominates every 10-syllable reading, `≥{s_unstress:2}`) is kept as a bounded reference row. But `build_for_N`'s overlay only pulled in **cross-unbounded** parses (`if (rank, i) not in pool_unb: continue`), and a fully-dominated length has none — so it fell back to the canonical base combo, freezing every function word unstressed.

**Fix.** `build_for_N` gains `full_forms=True`, passed for `extra_Ns` (dominated) lengths only. It also overlays cross-**bounded** parses, so each meter string gets its within-length min-score pronunciation. The sort key keeps unbounded < bounded then min-score, so surviving lengths are unaffected.

### This is display-only — the competition was always fair
`art=S` and `art=u` are **separate enumerated combos**, both always cross-bounded against the 9-syllable readings. The `art=S` `(ws)×5` (score 2) always competed and correctly *lost* to the fewer-violation elided reading — the elision genuinely removes the strong-beat `ate` violation. `full_forms` just surfaces that already-competing parse at its true best form instead of the canonical one. Nothing new starts competing; no parse changes status.

### Verification
- **674 pass** + new `test_dominated_length_shows_best_pronunciation`.
- **`best_parse` + score + `num_parses` byte-identical** vs 3.9.0 across all 2155 sonnet lines (scoped to dominated lengths; surviving lengths untouched).
- **Zero parse-time cost** — A/B on the sonnets: `full_forms` on 6.44s vs off 6.45s (`get_lpl` caches each combo; the cross-bounder already materialized them).

Ships as **3.9.1** (bump happens at the develop→master release, as before). Separate from the larger "one padded matrix for all lengths" idea discussed — that's a storage refactor (+ MaxEnt-on-mixed-N), orthogonal to this display fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
