### PR TITLE
MaxEnt trains on mixed-N (ragged) lines — recovers all elision lines

### DIFF
--- a/prosodic/parsing/maxent.py
+++ b/prosodic/parsing/maxent.py
@@ -118,7 +118,6 @@ class MaxEntTrainer:
         self._constraint_names = None  # expanded names (with zone suffixes)
         self._base_constraint_names = None  # original constraint names
         self._weights = None
-        self._n_skipped_ragged = 0  # ragged (mixed-N) lines dropped from training
         self._n_skipped_empty = 0   # oversized/empty lines with no viols matrix
 
     def _parse_text(self, text_input, lang=DEFAULT_LANG):
@@ -170,7 +169,6 @@ class MaxEntTrainer:
         self._line_data = []
         self._base_constraint_names = None
         n_unmatched = 0
-        self._n_skipped_ragged = 0
         self._n_skipped_empty = 0
 
         # first pass: collect raw data and find max syllable count for zone naming
@@ -183,14 +181,26 @@ class MaxEntTrainer:
 
             # Oversized/empty lines come back as a bare ParseList([]) with no
             # violation matrix — skip them instead of crashing on _all_viols.
-            # Ragged (mixed-syllable-count pool_forms) lines have a per-scansion
-            # viols LIST, not a fixed-width array — skip them too (rare). Count
-            # each skip reason so the drop is surfaced in the warning below
-            # rather than vanishing silently. Check _ragged first: a ragged
-            # line's _all_viols is a list with no .shape.
+            # Check _ragged first: a ragged line's _all_viols is a LIST of
+            # per-scansion (N_k, C) arrays with no .shape.
             viols = getattr(lpl, "_all_viols", None)
             if getattr(lpl, "_ragged", False):
-                self._n_skipped_ragged += 1
+                # Mixed-N (ragged) line: candidates differ in syllable count
+                # (elision / pronunciation variants). TRAINABLE: MaxEnt consumes
+                # the N axis immediately — zone_split collapses every candidate to
+                # a (C*Z) feature vector whose names are N-independent (only the
+                # zone boundaries shift with each row's own N) — so mixed-N
+                # candidates stack into the ordinary (S, C*Z) softmax. The second
+                # pass zone-splits these per-row. (Previously skipped wholesale,
+                # which dropped exactly the elision lines from every gold set —
+                # 12/120 of the foot gold.)
+                if not viols:
+                    self._n_skipped_empty += 1
+                    continue
+                if self._base_constraint_names is None:
+                    self._base_constraint_names = list(lpl._constraint_names)
+                max_nsylls = max(max_nsylls, max(v.shape[0] for v in viols))
+                raw_entries.append((line_text, lpl))
                 continue
             if viols is None or viols.shape[0] == 0:
                 self._n_skipped_empty += 1
@@ -213,7 +223,18 @@ class MaxEntTrainer:
 
         # second pass: zone-split and pad to consistent feature dimension
         for line_text, lpl in raw_entries:
-            viols_sum = self._zone_split(lpl._all_viols)  # (S, C*Z_local)
+            if getattr(lpl, "_ragged", False):
+                # Mixed-N: zone-split each (N_k, C) row by its OWN length (the same
+                # per-row split the ragged scoring path uses), then stack. Rows can
+                # differ in width only under zones="foot" (Z grows with N) — right-
+                # pad to the widest; the shared n_features pad below does the rest.
+                per = [self._zone_split(v[None])[0] for v in lpl._all_viols]
+                width = max(p.shape[0] for p in per)
+                viols_sum = np.zeros((len(per), width), dtype=np.float64)
+                for j, p in enumerate(per):
+                    viols_sum[j, :p.shape[0]] = p
+            else:
+                viols_sum = self._zone_split(lpl._all_viols)  # (S, C*Z_local)
             n_scansions = viols_sum.shape[0]
 
             # pad if this line has fewer zones than the max
@@ -254,11 +275,6 @@ class MaxEntTrainer:
             warn_parts.append(
                 f"{n_total - n_matched}/{n_total} lines had no matching "
                 f"scansion among parser candidates (syllable count mismatch?)"
-            )
-        if self._n_skipped_ragged:
-            warn_parts.append(
-                f"{self._n_skipped_ragged} line(s) skipped as "
-                f"ragged/mixed-syllable-count and not trained"
             )
         if warn_parts:
             log.warning("; ".join(warn_parts))

--- a/scripts/maxent_by_meter.py
+++ b/scripts/maxent_by_meter.py
@@ -72,21 +72,22 @@ def run_zones(df, reg):
 
 
 def run_unmatched(df):
-    print("\n=== C. DROPPED/UNMATCHED — which gold lines MaxEnt can't use, and why ===")
+    print("\n=== C. COVERAGE — gold lines used per meter (mixed-N lines now train) ===")
     for m in METERS:
         g = df[df.meter == m]
         tr = _trainer(g, reg=1.0)
         used, in_data = _matched(tr)
-        ragged = tr._n_skipped_ragged + tr._n_skipped_empty
-        not_cand = in_data - used                      # in _line_data but gold != a candidate
-        print(f"  {m:10s}: {used}/30 used   ({ragged} dropped ragged/mixed-N, "
+        n_unique = g["line"].nunique()                  # duplicate lines fold (freq sums)
+        dropped = n_unique - in_data                    # oversized/empty only, now
+        not_cand = in_data - used                       # in _line_data but gold != a candidate
+        print(f"  {m:10s}: {used}/{n_unique} unique lines used   ({dropped} dropped, "
               f"{not_cand} gold not among candidate scansions)")
-        # name the ragged (mixed-N, usually elision) lines
+        # name the mixed-N (elision) lines — previously skipped, now trained
         for _, r in g.iterrows():
             t = TextModel(r["line"])
             if t.lines and getattr(t.lines[0].parses, "_ragged", False):
                 note = f"  ({r['note']})" if isinstance(r.get("note"), str) else ""
-                print(f"        ragged: {r['line'][:50]!r}{note}")
+                print(f"        mixed-N (trained): {r['line'][:50]!r}{note}")
 
 
 def run_joint(df, reg, tau):

--- a/tests/test_maxent.py
+++ b/tests/test_maxent.py
@@ -4,7 +4,7 @@ Targets the module's public surface and the previously-uncovered branches:
 the zone helpers ("initial" / "foot" / int N / invalid), the foot-zone
 padding path in _build_line_data, load_annotations (list / DataFrame /
 pre-built-TextModel), the train() no-data guard, predict() / report() /
-apply_to_meter(), and the ragged-skip (mixed-syllable-count) accounting +
+apply_to_meter(), mixed-N (ragged) line training +
 warning.
 
 Kept fast by training on 1-2 short lines with light regularization; the
@@ -334,25 +334,36 @@ def test_fit_zones_foot_pads_shorter_lines():
 
 
 # ---------------------------------------------------------------------------
-# Ragged (mixed-syllable-count) lines: skipped, counted, warned
+# Ragged (mixed-syllable-count) lines: trained, not skipped
 # ---------------------------------------------------------------------------
 
-def test_ragged_line_skipped_counted_and_warned(monkeypatch):
+def test_ragged_line_trains():
     # "fire"/"flower" carry an elided 1-syllable variant alongside the
     # 2-syllable one; a line built from them pools parses of different lengths
-    # and comes back ragged. Ragged lines can't be stacked into a fixed-width
-    # feature matrix, so they're dropped from training, counted, and surfaced.
-    captured = []
-    monkeypatch.setattr(
-        maxent_mod.log, "warning", lambda msg, *a, **k: captured.append(msg)
-    )
-
+    # and comes back ragged. MaxEnt consumes the syllable axis immediately
+    # (zone_split -> a (C*Z) feature vector whose names are N-independent), so
+    # each candidate zone-splits by its OWN length and mixed-N candidates stack
+    # into the ordinary softmax. Ragged lines used to be dropped wholesale,
+    # which excluded exactly the elision lines from every gold set (12/120 of
+    # the foot gold).
     tr = MaxEntTrainer(Meter(), regularization=10.0, zones=None)
     tr.load_text([LINE1, RAGGED], IAMBIC)
+    assert len(tr._line_data) == 2                   # BOTH lines kept
+    # the ragged line's candidates include multiple syllable counts, and its
+    # feature matrix is rectangular (stacked per-row zone splits)
+    ragged_ld = next(ld for ld in tr._line_data if ld["text"] == RAGGED)
+    lens = {len(s) for s in ragged_ld["scansions"]}
+    assert len(lens) > 1
+    assert ragged_ld["viols"].ndim == 2
+    tr.train()
+    assert tr._train_params["converged"] is True
 
-    assert tr._n_skipped_ragged >= 1                 # counter incremented
-    assert len(tr._line_data) == 1                   # only the clean line kept
-    assert any("ragged" in m for m in captured)      # warning surfaced
+    # same under zones (per-row boundaries shift with each candidate's N)
+    trz = MaxEntTrainer(Meter(), regularization=10.0, zones=3)
+    trz.load_text([LINE1, RAGGED], IAMBIC)
+    assert len(trz._line_data) == 2
+    trz.train()
+    assert trz._train_params["converged"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +381,6 @@ def test_oversized_line_skipped_as_empty():
     tr = MaxEntTrainer(Meter(), regularization=10.0, zones=None)
     tr.load_text([LINE1, prose], IAMBIC)
     assert tr._n_skipped_empty == 1
-    assert tr._n_skipped_ragged == 0
     assert len(tr._line_data) == 1
     tr.train()  # still trainable on the surviving line
     assert tr._train_params["converged"] is True


### PR DESCRIPTION
## MaxEnt trains on mixed-N (ragged) lines — all elision lines recovered

### The insight that shrank the plan
This began as Phase 2 of the "padded matrix" refactor (pad every parse to `(P, N_max, C)` + a lengths vector). Re-reading the trainer showed the headline payoff doesn't need the representation change at all: **MaxEnt consumes the syllable axis immediately** — `zone_split` collapses every candidate to a `(C×Z)` feature vector whose *names* are N-independent (only the zone *boundaries* shift with each parse's own N). So mixed-N candidates can compete in the ordinary `(S, C×Z)` softmax; the ragged skip was never necessary.

### The fix (~15 lines)
`_build_line_data` now zone-splits each ragged `(N_k, C)` row by its **own** length — the same per-row split the ragged *scoring* path already uses (`vectorized.py:1144`) — and stacks the rows. Parsing, `best_parse`, and every consumer outside training are untouched; there is **no byte-identity risk** by construction.

### What it recovers
The wholesale skip dropped exactly the **elision** lines from every gold set — 12/120 of the foot gold (`tedious→TED-yus`, `heaven→heav'n`, `sep'rate`, `trav'ling`, …): the lines that carry the most information about optional syllable reduction.

- Foot-gold coverage: **108/120 → 120/120 annotations** (119/119 unique lines; the one residual "drop" was the duplicated Raven refrain, correctly folded with frequency 2.0).
- The by-meter findings **sharpen** with full data: iambic's line-final strictness gradient (`w_stress` 0.41 → 0.95 → 1.56 across thirds) vs trochaic's line-initial mirror (1.38 → 0.88 → 0.73) both hold.

### Cleanup + tests
- Removed the now-dead `_n_skipped_ragged` counter and its warning.
- Inverted the skip test into `test_ragged_line_trains` (flat + `zones=3`, both converge; asserts the mixed-N candidate set really spans multiple lengths).
- `scripts/maxent_by_meter.py` section C reports coverage over unique lines.
- **676 pass.**

### Status of the padded-matrix idea
Phase 2 (this capability) is done surgically. Phases 1/3 — the pure-cleanup padding of the ~6 remaining ragged branches in scoring/display — are **deferred**: modest benefit, and they carry tie-break byte-identity risk for no new capability. Revisit only if the ragged branches start accumulating again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
