### PR TITLE
Elite bounding pre-screen on the torch device (parse GPU 5.2s → 4.1s, byte-identical)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,22 +305,26 @@ Run `python -m prosodic.profiling` to regenerate.
 | Step | v2 | v3 | Speedup |
 |---|---|---|---|
 | Init (tokenize + pronunciations + entities) | 5.29s | 2.2s | 2x |
-| Parse (CPU) | 72.97s | 6.8s | 11x |
-| Parse (GPU) | 72.97s | 5.2s | 14x |
-| **End-to-end (CPU)** | **78.3s** | **9.0s** | **9x** |
-| **End-to-end (GPU)** | **78.3s** | **7.5s** | **11x** |
-| **DF-only (no entities, GPU)** | **78.3s** | **6.2s** | **13x** |
+| Parse (CPU) | 72.97s | 6.4s | 11x |
+| Parse (GPU) | 72.97s | 4.1s | 18x |
+| **End-to-end (CPU)** | **78.3s** | **8.6s** | **9x** |
+| **End-to-end (GPU)** | **78.3s** | **6.3s** | **12x** |
+| **DF-only (no entities, GPU)** | **78.3s** | **5.1s** | **15x** |
 | Syntax (dep parse) | 160.2s | 3.3s | 49x |
 
 An earlier revision of this table showed Parse at 1.9s — that predates the v1-semantics
 restoration (PRs #164–169): variant pooling × verse elision means ~89% of sonnet lines
 now carry multiple pronunciation combos (mean 9/line), each evaluated and cross-bounded,
 plus mixed-N dominated-length retention. That ~3× is purchased semantics (parity ρ
-0.9475 vs the 2020 v1 data), not regression. The pooling layer itself is vectorized
-(index-aligned overlay in `build_for_N` — same-N combos share one scansion enumeration,
-so dedup-by-meter-string ≡ per-index argmin, verified byte-identical; was 4.0s of
-Python loops, now 1.8s). GPU beats CPU again at this workload — the elite pre-screen
-note that once favored CPU flipped back when pooling re-inflated the kernel's input.
+0.9475 vs the 2020 v1 data), not regression. Two vectorization passes clawed most of it
+back, each verified byte-identical by a full before/after dump diff: (1) the pooling
+overlay (`build_for_N`) — same-N combos share one scansion enumeration, so
+dedup-by-meter-string ≡ per-index argmin (was 4.0s of Python loops, now 1.8s); (2) the
+elite bounding pre-screen runs on the torch device when available
+(`_elite_screen_torch`, 15x over numpy on MPS — the pooled combos push its input to
+~15K rows/call; any sound screen yields the same final mask by transitivity of
+dominance). GPU beats CPU again at this workload — the old "CPU edges out GPU" note
+flipped back when pooling re-inflated the kernels' inputs.
 
 **TTS pronunciation cache**: espeak results cached to `~/prosodic_data/data/{lang}_cache.tsv`. First run phonemizes ~671 words via espeak; subsequent runs load from cache. Cold init 1.9s → warm 0.56s.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,15 +302,20 @@ The `_syll_df`-backed canonical syllable count is essential for line/syllable sc
 
 Run `python -m prosodic.profiling` to regenerate.
 
-| Step | v2 | v3 | Speedup |
-|---|---|---|---|
-| Init (tokenize + pronunciations + entities) | 5.29s | 2.2s | 2x |
-| Parse (CPU) | 72.97s | 6.4s | 11x |
-| Parse (GPU) | 72.97s | 4.1s | 18x |
-| **End-to-end (CPU)** | **78.3s** | **8.6s** | **9x** |
-| **End-to-end (GPU)** | **78.3s** | **6.3s** | **12x** |
-| **DF-only (no entities, GPU)** | **78.3s** | **5.1s** | **15x** |
-| Syntax (dep parse) | 160.2s | 3.3s | 49x |
+| Step | v1 (1.3.8) | v2 | v3 | v3 vs v2 |
+|---|---|---|---|---|
+| Init (tokenize + pronunciations + entities) | 1.4s | 5.29s | 2.2s | 2x |
+| Parse (CPU) | 36.6s | 72.97s | 6.4s | 11x |
+| Parse (GPU) | 36.6s | 72.97s | 4.1s | 18x |
+| **End-to-end (CPU)** | **38.0s** | **78.3s** | **8.6s** | **9x** |
+| **End-to-end (GPU)** | **38.0s** | **78.3s** | **6.3s** | **12x** |
+| **DF-only (no entities, GPU)** | **38.0s** | **78.3s** | **5.1s** | **15x** |
+| Syntax (dep parse) | — | 160.2s | 3.3s | 49x |
+
+v1 measured 2026-07-10 via the `cmp_prosodics` harness (same machine, whole-sonnets
+Text + parse, dict warm; `v1_3_8/profile_v1_sonnets.py` there). Note the shape of the
+history: **v1's pruned branch-and-bound was ~2× faster than the 2024 v2 rewrite** —
+the oft-quoted "78s legacy" figure is v2, not v1. v3 is ~9× v1, ~18× v2 on parse (GPU).
 
 An earlier revision of this table showed Parse at 1.9s — that predates the v1-semantics
 restoration (PRs #164–169): variant pooling × verse elision means ~89% of sonnet lines

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -925,6 +925,32 @@ def _elite_screen(viol_sums, K=BOUNDING_ELITE_K, block=512):
     return dominated
 
 
+def _elite_screen_torch(viol_sums, device, K=BOUNDING_ELITE_K, budget=64_000_000):
+    """GPU twin of `_elite_screen` — the same (block, K, S, C) difference tensor,
+    on the torch device. 15x faster than numpy on MPS over the real sonnet
+    workloads (pooled combos push L to ~15K rows per call, exactly where the
+    screen's reductions dominate the parse profile). Tie-breaks in the K-elite
+    pick (topk vs argpartition) may select different elites, but ANY sound screen
+    yields the same FINAL unbounded mask — a candidate dominated by a screened-out
+    candidate is, by transitivity of strict dominance, also dominated by an elite
+    or a survivor — verified mask-identical on all 18 real arrays of a sonnets
+    parse. `budget` caps the difference tensor's element count."""
+    import torch
+    v = torch.from_numpy(np.ascontiguousarray(viol_sums, dtype=np.int16)).to(device)
+    L, S, C = v.shape
+    k = min(K, S)
+    totals = v.to(torch.int32).sum(dim=2)                            # (L, S)
+    idx = torch.topk(totals, k=k, dim=1, largest=False).indices      # (L, k)
+    elite = torch.gather(v, 1, idx.unsqueeze(-1).expand(-1, -1, C))  # (L, k, C)
+    block = max(1, budget // max(1, k * S * C))
+    out = torch.zeros((L, S), dtype=torch.bool, device=device)
+    for l0 in range(0, L, block):
+        l1 = min(l0 + block, L)
+        diff = elite[l0:l1, :, None, :] - v[l0:l1, None, :, :]       # (b, k, S, C)
+        out[l0:l1] = ((diff <= 0).all(3) & (diff < 0).any(3)).any(1)
+    return out.cpu().numpy()
+
+
 def _bounding_exact(viol_sums):
     """Dispatch the exact pairwise kernel (GPU if available)."""
     device = get_device()
@@ -938,7 +964,9 @@ def _bounding_screened(viol_sums):
     L, S, C = viol_sums.shape
     if S <= 2 * BOUNDING_ELITE_K:
         return _bounding_exact(viol_sums)
-    dominated = _elite_screen(viol_sums)
+    device = get_device()
+    dominated = (_elite_screen_torch(viol_sums, device) if device is not None
+                 else _elite_screen(viol_sums))
     surv = ~dominated
     counts = surv.sum(axis=1)
     s_max = int(counts.max())

--- a/prosodic/profiling.py
+++ b/prosodic/profiling.py
@@ -142,6 +142,14 @@ V2_INIT = 5.29
 V2_PARSE = 72.97
 V2_SYNTAX = 160.20  # stanza constituency + depparse, 522 sentences
 
+# v1.3.8 reference timings (cmp_prosodics harness, same machine, measured
+# 2026-07-10: whole-sonnets Text + parse, dict warm). NOTE the shape of the
+# history: v1's pruned branch-and-bound was ~2x FASTER than the 2024 v2
+# rewrite; the oft-quoted "78s legacy" number is v2, not v1.
+V1_INIT = 1.4
+V1_PARSE = 36.6
+V1_SYNTAX = None  # v1 had no syntax/phrasal-stress layer
+
 
 def format_markdown(results, meta):
     """Format results as a comparison table."""
@@ -155,32 +163,36 @@ def format_markdown(results, meta):
 
     rows = []
 
-    def row(step, v2, v3):
+    def row(step, v1, v2, v3):
         speedup = f"{v2/v3:.0f}x" if v2 and v3 and v3 > 0 else "—"
+        v1s = f"{v1:.2f}s" if v1 else "—"
         v2s = f"{v2:.2f}s" if v2 else "—"
         v3s = f"{v3:.2f}s" if v3 else "—"
-        return f"| {step} | {v2s} | {v3s} | {speedup} |"
+        return f"| {step} | {v1s} | {v2s} | {v3s} | {speedup} |"
 
-    rows.append(row("Init (tokenize + pronunciations + entities)", V2_INIT, init_v3))
-    rows.append(row("Parse (CPU)", V2_PARSE, parse_cpu_v3))
+    rows.append(row("Init (tokenize + pronunciations + entities)", V1_INIT, V2_INIT, init_v3))
+    rows.append(row("Parse (CPU)", V1_PARSE, V2_PARSE, parse_cpu_v3))
     if parse_gpu_v3:
-        rows.append(row("Parse (GPU)", V2_PARSE, parse_gpu_v3))
+        rows.append(row("Parse (GPU)", V1_PARSE, V2_PARSE, parse_gpu_v3))
+    e2e_v1 = V1_INIT + V1_PARSE
     e2e_v2 = V2_INIT + V2_PARSE
-    rows.append(row("**End-to-end (CPU)**", e2e_v2, init_v3 + parse_cpu_v3))
+    rows.append(row("**End-to-end (CPU)**", e2e_v1, e2e_v2, init_v3 + parse_cpu_v3))
     if parse_gpu_v3:
-        rows.append(row("**End-to-end (GPU)**", e2e_v2, init_v3 + parse_gpu_v3))
+        rows.append(row("**End-to-end (GPU)**", e2e_v1, e2e_v2, init_v3 + parse_gpu_v3))
     init_only = r.get("init", 0)
     if parse_gpu_v3:
         batch_total = init_only + parse_gpu_v3
-        rows.append(row("**DF-only (no entities, GPU)**", e2e_v2, batch_total))
+        rows.append(row("**DF-only (no entities, GPU)**", e2e_v1, e2e_v2, batch_total))
     if syntax_overhead is not None:
         syntax_v3 = r.get("syntax_init", 0)
-        rows.append(row("Syntax (dep parse)", V2_SYNTAX, syntax_v3))
+        rows.append(row("Syntax (dep parse)", V1_SYNTAX, V2_SYNTAX, syntax_v3))
 
     lines = [
-        f"Shakespeare sonnets ({n} lines). `python -m prosodic.profiling`\n",
-        "| Step | v2 | v3 | Speedup |",
-        "|---|---|---|---|",
+        f"Shakespeare sonnets ({n} lines). `python -m prosodic.profiling`",
+        "(v1.3.8 measured via the cmp_prosodics harness, same machine; "
+        "speedup column = v3 over v2.)\n",
+        "| Step | v1 | v2 | v3 | v3 vs v2 |",
+        "|---|---|---|---|---|",
         *rows,
     ]
 


### PR DESCRIPTION
## Elite bounding pre-screen on the torch device — parse GPU 5.2s → 4.1s

The pre-screen was numpy-only while the exact pairwise kernel already dispatched to torch. The pooled pronunciation combos push the screen's input to **~15K rows per call**, which made it the top cost of the parse after #182.

**Profiled on the real workload** (18 captured arrays from a sonnets parse, not synthetic): numpy **1666ms** vs MPS **110ms** — **15×**. `_elite_screen_torch` is the same `(block, K, S, C)` difference-tensor computation with a memory-budgeted block; CPU-only machines keep the numpy screen, untouched.

### Correctness
`topk` vs `argpartition` tie-breaks can pick different K-elites, but **any sound screen yields the same final unbounded mask**: a candidate dominated by a screened-out candidate is, by transitivity of strict dominance, also dominated by an elite or a survivor. Verified three ways:
- final bounding masks **identical on all 18** captured real arrays;
- the full dump diff (2239 lines × every field, sonnets + Byron + Browning) is **byte-identical vs the pre-#182 baseline** — both vectorization passes compounded, zero output change;
- **676 tests pass**.

### Canonical numbers (`python -m prosodic.profiling`)
| | before #182 | after #182 | **after this** |
|---|---|---|---|
| Parse (GPU/MPS) | 6.46s | 5.24s | **4.13s** (18× over v2) |
| End-to-end (GPU) | 8.66s | 7.45s | **6.30s** |
| warm min-of-3 | ~6.4s | ~4.9s | **3.29s** |

CPU path unchanged. CLAUDE.md table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
