### PR TITLE
Release-review fixes for 3.10.0 (loader robustness + invariant hardening)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ The parser is always vectorized and exhaustive — it evaluates ALL possible sca
 
 **Parsing flow:** `TextModel.parse()` → `parse_batch_from_df(syll_df, meter)` → groups by line, extracts features from numpy arrays → `evaluate_constraints_batch()` broadcasts features against scansion matrices → `compute_bounding_batch()` on GPU → results stored by line_num, attached to Entity lines lazily.
 
-**Bounding optimization:** Lines with a perfect parse (0 violations) skip the O(S²) pairwise comparison entirely — the perfect scansion bounds everything else. Non-perfect lines go through an **elite pre-screen** first: candidates dominated by one of the K=16 lowest-total candidates are eliminated in O(K·S) (mean ~3 survivors of ~180 on the sonnets), and the exact pairwise kernel runs only on the survivors. Exact by transitivity of dominance — byte-identical to full pairwise (tested). CPU parse is now ≈ GPU parse; the GPU is no longer needed for parsing.
+**Bounding optimization:** Lines with a perfect parse (0 violations) skip the O(S²) pairwise comparison entirely — the perfect scansion bounds everything else. Non-perfect lines go through an **elite pre-screen** first: candidates dominated by one of the K=16 lowest-total candidates are eliminated in O(K·S) (mean ~3 survivors of ~180 on the sonnets), and the exact pairwise kernel runs only on the survivors. Exact by transitivity of dominance — byte-identical to full pairwise (tested). With pronunciation-variant pooling the kernels' inputs grew (~15K rows/call) and the GPU is again the faster path (the elite screen itself runs on the torch device when available — see the Performance table); CPU remains fully supported and byte-identical.
 
 ### MaxEnt Weight Learning (`parsing/maxent.py`)
 

--- a/docs/methods/parse-path-unification.md
+++ b/docs/methods/parse-path-unification.md
@@ -96,6 +96,8 @@ bridge — the full unification. Keep the public signature.
 - [x] `Meter` bare-`WordTokenList` fallback → DF (via `parse_units_from_df`, with a
       fresh-`TextModel` path for a parentless list).
 - [x] `ParseSlot.wordform` DF-safe (`None` off the DF path; had no callers).
+- [x] `ParseSlot.syll` (the other §1b entity-chain accessor) DELETED in the 3.10.0
+      audit — zero callers; `slot.unit` is the replacement.
 - [x] **DELETE `parse_batch` + `_pool_combo_parses` + `extract_features` +
       `_extract_features_hybrid`** (~410 lines). One parser (`parse_batch_from_df` /
       `_pool_candidates`) remains. 673 tests pass; web + `best_parse` unchanged.

--- a/docs/reference/analysis.feet.Foot.qmd
+++ b/docs/reference/analysis.feet.Foot.qmd
@@ -11,7 +11,7 @@ construction.
 
 Attributes: `pattern` ('wws'), `label` ('anapest'), `head` ('rising'/'falling'/
 'none'/'ambiguous'), `is_substituted` (inverts the line head), `slots`
-(ParseSlots), `sylls`/`syllables` (the syllable units).
+(ParseSlots), `sylls` (the syllable units).
 
 ## Attributes
 

--- a/docs/reference/parsing.maxent.MaxEntTrainer.qmd
+++ b/docs/reference/parsing.maxent.MaxEntTrainer.qmd
@@ -56,12 +56,14 @@ Load annotated scansion data and parse all lines.
 
 Args:
     data: one of —
-      * a CSV/TSV file **path** (str or Path) — read into a DataFrame (`.tsv`/
-        `.txt` → tab-separated, else comma);
+      * a CSV/TSV file **path** (str or Path) — the delimiter is sniffed
+        (comma, tab, semicolon), so a comma-separated `.txt` or a
+        tab-separated `.csv` both load;
       * a list of `(line_text, scansion)` or `(line_text, scansion, frequency)`
-        tuples (frequency defaults to 1.0);
+        tuples (frequency defaults to 1.0; extra trailing fields ignored),
+        or a list of dicts with liberal keys;
       * a DataFrame, columns matched liberally by
-        `_normalize_annotation_columns` (text|line, scansion, optional freq).
+        `_normalize_annotation_columns` (line|text, scansion, optional freq).
     lang: language code for parsing.
     text: optional pre-built TextModel (e.g. with syntax=True).
 

--- a/prosodic/analysis/feet.py
+++ b/prosodic/analysis/feet.py
@@ -52,7 +52,7 @@ class Foot:
 
     Attributes: `pattern` ('wws'), `label` ('anapest'), `head` ('rising'/'falling'/
     'none'/'ambiguous'), `is_substituted` (inverts the line head), `slots`
-    (ParseSlots), `sylls`/`syllables` (the syllable units)."""
+    (ParseSlots), `sylls` (the syllable units)."""
 
     __slots__ = ("pattern", "label", "head", "is_substituted", "slots", "sylls")
 

--- a/prosodic/parsing/maxent.py
+++ b/prosodic/parsing/maxent.py
@@ -9,10 +9,12 @@ Based on Goldwater & Johnson (2003) and Bruce Hayes' MaxEnt OT framework.
 Usage:
     from prosodic.parsing.maxent import MaxEntTrainer
 
-    # annotations: list of (line_text, scansion_str, frequency)
-    # or a DataFrame with columns: text, scansion, frequency
+    # annotations: a CSV/TSV file path (delimiter sniffed, extra columns
+    # ignored — e.g. data/tagged_samples/foot-gold.csv loads directly),
+    # a list of (line_text, scansion[, frequency]) tuples or dicts,
+    # or a DataFrame with liberal columns (line|text, scansion, freq)
     trainer = MaxEntTrainer(meter)
-    trainer.load_annotations(annotations)
+    trainer.load_annotations('annotations.csv')
     trainer.train()
     trainer.report()
 
@@ -284,52 +286,83 @@ class MaxEntTrainer:
     @staticmethod
     def _normalize_annotation_columns(df):
         """Map liberal column names to canonical text/scansion/frequency and keep only
-        those. The text column may be named `text` or `line`/`line_text`; the target is
-        `scansion` (or `target`/`target_scansion`); an optional frequency column
-        (`frequency`/`freq`/`weight`/`count`) defaults to 1.0. Extra columns (meter,
-        poem, note, …) are ignored — so a gold CSV like data/tagged_samples/foot-gold.csv
-        loads directly."""
+        those. The line column may be named `line`/`line_text`/`text` — **`line` wins
+        when several are present** (in DH corpora `text` is often the WORK's title/id
+        while `line` holds the verse line; a warning names the loser). The target is
+        `scansion` (or `target`/`target_scansion`); an optional `frequency`/`freq`
+        column defaults to 1.0 (`weight`/`count` are deliberately NOT treated as
+        frequency — a syllable-`count` column would silently multiply long lines'
+        gradient mass). Rows with a blank line/scansion are dropped with a warning;
+        non-numeric or missing frequencies default to 1.0 with a warning. Extra columns
+        (meter, poem, note, …) are ignored — so a gold CSV like
+        data/tagged_samples/foot-gold.csv loads directly."""
         lower = {str(c).lower(): c for c in df.columns}
         def pick(*names):
-            for n in names:
-                if n in lower:
-                    return lower[n]
-            return None
-        tcol = pick("text", "line", "line_text")
+            found = [lower[n] for n in names if n in lower]
+            if len(found) > 1:
+                log.warning(
+                    f"annotation data has multiple candidate columns {found}; "
+                    f"using {found[0]!r}")
+            return found[0] if found else None
+        tcol = pick("line", "line_text", "text")
         scol = pick("scansion", "target", "target_scansion")
         if tcol is None or scol is None:
             raise ValueError(
-                "annotation data needs a text column (text/line) and a scansion "
-                f"column (scansion/target); got {list(df.columns)}")
-        fcol = pick("frequency", "freq", "weight", "count")
-        out = pd.DataFrame({"text": df[tcol].astype(str), "scansion": df[scol].astype(str)})
-        out["frequency"] = df[fcol].astype(float) if fcol else 1.0
-        return out
+                "annotation data needs a line column (line/text) and a scansion "
+                f"column (scansion/target); got {list(df.columns)} — if you loaded "
+                "from a file, check the delimiter was detected correctly")
+        out = pd.DataFrame({"text": df[tcol], "scansion": df[scol]})
+        # drop blank/missing rows BEFORE astype(str) — otherwise a NaN cell becomes
+        # the literal string 'nan' and silently trains as a one-word line
+        bad = (out["text"].isna() | out["scansion"].isna()
+               | (out["text"].astype(str).str.strip() == "")
+               | (out["scansion"].astype(str).str.strip() == ""))
+        if bad.any():
+            log.warning(f"dropping {int(bad.sum())} annotation row(s) with a "
+                        f"blank line/scansion cell")
+            out, df = out[~bad], df[~bad]
+        out["text"] = out["text"].astype(str)
+        out["scansion"] = out["scansion"].astype(str)
+        fcol = pick("frequency", "freq")
+        if fcol:
+            freqs = pd.to_numeric(df[fcol], errors="coerce")
+            n_bad = int(freqs.isna().sum())
+            if n_bad:
+                log.warning(f"{n_bad} missing/non-numeric value(s) in frequency "
+                            f"column {fcol!r}; defaulting those to 1.0")
+            out["frequency"] = freqs.fillna(1.0).astype(float)
+        else:
+            out["frequency"] = 1.0
+        return out.reset_index(drop=True)
 
     def load_annotations(self, data, lang=DEFAULT_LANG, text=None):
         """Load annotated scansion data and parse all lines.
 
         Args:
             data: one of —
-              * a CSV/TSV file **path** (str or Path) — read into a DataFrame (`.tsv`/
-                `.txt` → tab-separated, else comma);
+              * a CSV/TSV file **path** (str or Path) — the delimiter is sniffed
+                (comma, tab, semicolon), so a comma-separated `.txt` or a
+                tab-separated `.csv` both load;
               * a list of `(line_text, scansion)` or `(line_text, scansion, frequency)`
-                tuples (frequency defaults to 1.0);
+                tuples (frequency defaults to 1.0; extra trailing fields ignored),
+                or a list of dicts with liberal keys;
               * a DataFrame, columns matched liberally by
-                `_normalize_annotation_columns` (text|line, scansion, optional freq).
+                `_normalize_annotation_columns` (line|text, scansion, optional freq).
             lang: language code for parsing.
             text: optional pre-built TextModel (e.g. with syntax=True).
         """
-        import os
         if isinstance(data, (str, os.PathLike)):
-            sep = "\t" if str(data).endswith((".tsv", ".txt")) else ","
-            df = pd.read_csv(data, sep=sep)
+            # sniff the delimiter rather than guessing from the extension
+            df = pd.read_csv(data, sep=None, engine="python")
         elif isinstance(data, list):
-            rows = []
-            for r in data:
-                r = tuple(r)
-                rows.append(r if len(r) >= 3 else (r[0], r[1], 1.0))
-            df = pd.DataFrame(rows, columns=["text", "scansion", "frequency"])
+            if data and isinstance(data[0], dict):
+                df = pd.DataFrame(data)   # records: columns come from the dict keys
+            else:
+                rows = []
+                for r in data:
+                    r = tuple(r)[:3]      # extra trailing fields ignored, like the DF path
+                    rows.append(r if len(r) >= 3 else (r[0], r[1], 1.0))
+                df = pd.DataFrame(rows, columns=["text", "scansion", "frequency"])
         else:
             df = data.copy()
         df = self._normalize_annotation_columns(df)

--- a/prosodic/parsing/vectorized.py
+++ b/prosodic/parsing/vectorized.py
@@ -75,11 +75,15 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
     pool_unb = set()
     pool_unb_arr = {}   # rank -> (S,) bool: cross-pool unbounded (same info as pool_unb)
     if fvecs:
-        fv = np.array(fvecs); zv = np.array(zvecs); nn = np.array(uN)
-        same_n = nn[:, None] == nn[None, :]
-        zdom = (zv[:, None, :] <= zv[None, :, :]).all(axis=2) & (zv[:, None, :] < zv[None, :, :]).any(axis=2)
+        fv = np.array(fvecs); nn = np.array(uN)
         fdom = (fv[:, None, :] <= fv[None, :, :]).all(axis=2) & (fv[:, None, :] < fv[None, :, :]).any(axis=2)
-        dom = np.where(same_n, zdom, fdom)
+        if bound_zones is None:
+            dom = fdom   # zone == flat identically; skip the doubled U^2*C broadcast
+        else:
+            zv = np.array(zvecs)
+            same_n = nn[:, None] == nn[None, :]
+            zdom = (zv[:, None, :] <= zv[None, :, :]).all(axis=2) & (zv[:, None, :] < zv[None, :, :]).any(axis=2)
+            dom = np.where(same_n, zdom, fdom)
         np.fill_diagonal(dom, False)
         alive = ~dom.any(axis=0)
         pool_unb = {(urank[k], uidx[k]) for k in range(len(urank)) if alive[k]}
@@ -130,6 +134,14 @@ def _pool_candidates(candidates, meter, ci_use, bound_zones, build_sylls, parse_
         l0 = get_lpl(base)
         S = len(l0._all_scansions)
         R = len(group)
+        # cheap guard for the load-bearing invariant above: every same-N combo must
+        # carry the SAME enumeration object. If a future change filters candidates
+        # per-combo (or builds a second enumeration source), index alignment breaks
+        # and this fails loudly instead of silently mispooling.
+        base_scans = candidates[base][2]
+        assert all(candidates[r][2] is base_scans for r in group[1:]), (
+            "same-N combos must share one scansion enumeration "
+            "(index-aligned overlay invariant)")
         no_unb = np.zeros(S, dtype=bool)
         valid = np.zeros((R, S), dtype=bool)
         bounded = np.ones((R, S), dtype=np.int8)
@@ -851,12 +863,15 @@ def _zone_split_batch(viols_4d, zones):
     flat (L, S, C) sum, identical to the previous bounding input.
     """
     if zones is None:
-        return viols_4d.sum(axis=2)
+        # int16 directly: counts are tiny (<= ~36) and every bounding kernel casts
+        # to int16 anyway — summing at int16 makes those casts no-op views and
+        # shrinks the (L, S, C) array 4x (~100MB/parse on large ambig batches)
+        return viols_4d.sum(axis=2, dtype=np.int16)
     from .maxent import zone_boundaries
     L, S, N, C = viols_4d.shape
     boundaries = zone_boundaries(zones, N)
     Z = len(boundaries)
-    out = np.zeros((L, S, C * Z), dtype=np.int64)
+    out = np.zeros((L, S, C * Z), dtype=np.int16)
     for z, (start, end) in enumerate(boundaries):
         out[:, :, z * C:(z + 1) * C] = viols_4d[:, :, start:end, :].sum(axis=2)
     return out
@@ -912,7 +927,7 @@ def _elite_screen_torch(viol_sums, device, K=BOUNDING_ELITE_K, budget=64_000_000
     v = torch.from_numpy(np.ascontiguousarray(viol_sums, dtype=np.int16)).to(device)
     L, S, C = v.shape
     k = min(K, S)
-    totals = v.to(torch.int32).sum(dim=2)                            # (L, S)
+    totals = v.sum(dim=2, dtype=torch.int32)                            # (L, S)
     idx = torch.topk(totals, k=k, dim=1, largest=False).indices      # (L, k)
     elite = torch.gather(v, 1, idx.unsqueeze(-1).expand(-1, -1, C))  # (L, k, C)
     block = max(1, budget // max(1, k * S * C))
@@ -967,6 +982,11 @@ def compute_bounding_batch(viol_sums):
     Returns:
         (L, S) bool — unbounded mask per line
     """
+    # Bounding is dominance on integer violation COUNTS (weights apply only at
+    # scoring). The torch kernels cast to int16, which is lossless for counts but
+    # would silently truncate real-valued input — enforce the invariant once here.
+    assert np.issubdtype(np.asarray(viol_sums).dtype, np.integer), (
+        "bounding operates on integer violation counts")
     L, S, C = viol_sums.shape
     if S <= 1:
         return np.ones((L, S), dtype=bool)

--- a/prosodic/profiling.py
+++ b/prosodic/profiling.py
@@ -189,7 +189,8 @@ def format_markdown(results, meta):
 
     lines = [
         f"Shakespeare sonnets ({n} lines). `python -m prosodic.profiling`",
-        "(v1.3.8 measured via the cmp_prosodics harness, same machine; "
+        "(reference v1/v2 timings: Apple M-series, 2026-07, via the cmp_prosodics "
+        "harness; v3 columns are from THIS run on your machine; "
         "speedup column = v3 over v2.)\n",
         "| Step | v1 | v2 | v3 | v3 vs v2 |",
         "|---|---|---|---|---|",

--- a/scripts/foot_parse.py
+++ b/scripts/foot_parse.py
@@ -12,8 +12,9 @@ from prosodic.analysis.feet import foot_parse, FOOT_LABELS
 def parse(scansion):
     proms = [c == "s" for c in scansion.lower() if c in "sw"]
     s = "".join("s" if p else "w" for p in proms)
-    # disable the word-boundary tiebreak here (no word info): mark every position
-    # a "word start" so no boundary is penalized -> shows the pure foot-cost result.
+    # (the word-boundary tiebreak was retired as a null result — human foot
+    # boundaries hit word boundaries at chance rate; see foot-parsing.md §"negative
+    # results" — so this is the pure foot-cost result.)
     spans = foot_parse(proms)
     feet = [s[a:b] for a, b in spans]
     return "|".join(feet), feet

--- a/tests/test_maxent.py
+++ b/tests/test_maxent.py
@@ -272,6 +272,61 @@ def test_load_annotations_friendly_columns_and_path(tmp_path):
     assert len(tr3._annotations) == 1
 
 
+def test_load_annotations_robustness(tmp_path):
+    """Release-review regression guards for the liberal loader (each of these was a
+    verified defect): dict records, line-vs-text precedence, NaN frequency, long
+    tuples, blank cells, delimiter sniffing, and count-is-not-frequency."""
+    # (a) list of dicts — worked in 3.9.1; tuple(dict) yields KEYS and silently
+    # trained on the literal strings 'text'/'scansion'
+    tr = MaxEntTrainer(Meter(), regularization=10.0)
+    tr.load_annotations([{"text": LINE1, "scansion": IAMBIC, "frequency": 1.0}])
+    assert tr._annotations["text"].tolist() == [LINE1]
+    assert [ld for ld in tr._line_data if ld["observed"].sum() > 0]
+
+    # (b) `line` outranks `text` when both present (DH convention: text = work
+    # title/id, line = the verse line — training on titles converged to garbage)
+    df = pd.DataFrame({"text": ["Sonnet 18"], "line": [LINE1],
+                       "scansion": [IAMBIC]})
+    tr2 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr2.load_annotations(df)
+    assert tr2._annotations["text"].tolist() == [LINE1]
+
+    # (c) NaN frequency defaults to 1.0 (one blank cell used to poison the whole
+    # fit: observed never normalized, gradient NaN, all-zero weights, no error)
+    df3 = pd.DataFrame({"line": [LINE1, LINE2], "scansion": [IAMBIC, IAMBIC],
+                        "frequency": [1.0, float("nan")]})
+    tr3 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr3.load_annotations(df3)
+    assert tr3._annotations["frequency"].tolist() == [1.0, 1.0]
+    tr3.train()
+    assert tr3._train_params["converged"] is True
+
+    # (d) tuples longer than 3: extra trailing fields ignored, like the DF path
+    tr4 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr4.load_annotations([(LINE1, IAMBIC, 2.0, "iambic", "a note")])
+    assert tr4._annotations["frequency"].tolist() == [2.0]
+
+    # (e) a blank line cell is dropped, not trained as the literal string 'nan'
+    df5 = pd.DataFrame({"line": [LINE1, None], "scansion": [IAMBIC, IAMBIC]})
+    tr5 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr5.load_annotations(df5)
+    assert tr5._annotations["text"].tolist() == [LINE1]
+
+    # (f) comma-separated .txt path: delimiter is sniffed, not extension-guessed
+    fp = tmp_path / "gold.txt"
+    fp.write_text(f"line,scansion\n\"{LINE1}\",{IAMBIC}\n")
+    tr6 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr6.load_annotations(str(fp))
+    assert tr6._annotations["scansion"].tolist() == [IAMBIC]
+
+    # (g) a `count` column is NOT frequency (a syllable-count column would
+    # silently multiply long lines' gradient mass)
+    df7 = pd.DataFrame({"line": [LINE1], "scansion": [IAMBIC], "count": [12]})
+    tr7 = MaxEntTrainer(Meter(), regularization=10.0)
+    tr7.load_annotations(df7)
+    assert tr7._annotations["frequency"].tolist() == [1.0]
+
+
 def test_load_annotations_with_prebuilt_text():
     # text= branch: annotations attach to a pre-built (e.g. syntax) TextModel
     # instead of re-parsing the unique annotation strings.

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -378,6 +378,20 @@ def test_bounding_tiled_equals_reference():
     assert V._bounding_block_sizes(3, 20, 6, bytes_per_elem=8) == (3, 20, 20)
 
 
+def test_scansion_meter_string_bijection():
+    """The index-aligned pooling overlay (build_for_N) rests on the meter-string <->
+    scansion bijection within one enumeration: positions strictly alternate s/w, so a
+    per-syllable string's maximal runs recover its position split uniquely. Pin it —
+    if a future enumerator admits adjacent same-value positions (['w','w'] vs ['ww']),
+    this fails loudly instead of the pooler silently double-reporting meter strings."""
+    from prosodic.parsing.meter import Meter
+    m = Meter()
+    for n in range(2, 19):
+        scans = m.get_possible_scansions(n)
+        strings = ["".join(sc) for sc in scans]
+        assert len(strings) == len(set(strings)), f"duplicate meter string at N={n}"
+
+
 def test_elite_screen_torch_parity_on_cpu():
     """The torch elite pre-screen (`_elite_screen_torch`, normally dispatched only
     when a GPU device exists) must yield the SAME FINAL bounding mask as the numpy


### PR DESCRIPTION
## Release-review fixes (from `/review 186`: 8 angles, all findings verified by the finders themselves)

**Verdict on the release core: sound.** The index-alignment invariant was verified against the enumeration source (including the diagonal fallback) and reproduced the old dedup exactly on real pooled lines; the torch screen is value-safe (bounding always receives integer counts — spy-verified on a fitted zone-bounded parse); `reduceat` matches the old loop on 50 random ragged cases.

**Every confirmed defect clustered in the new annotation loader** — six fixes in one rewrite: the list-of-dicts regression (worked in 3.9.1; `tuple(dict)` yields keys → silently trained on the strings `'text'`/`'scansion'`), `line` now outranks `text` (DH convention: `text` is often the work title), one NaN frequency cell no longer poisons the entire fit, `weight`/`count` no longer masquerade as frequency, file delimiters are sniffed rather than extension-guessed, long tuples and blank cells handled.

**Hardening** (behavior-preserving, byte-identity-checked): the index-alignment invariant is now a runtime assert + a property test (was comment-only); an integer-dtype assert at the bounding entry; `_zone_split_batch` emits int16 (4× smaller arrays, downstream casts become no-ops); the doubled `zdom` broadcast skipped for unfitted meters; the torch up-cast fused into its reduction.

**Docs/consistency:** CLAUDE.md's self-contradiction on CPU-vs-GPU fixed; maxent's module docstring documents the new front door; the published `Foot` reference page no longer advertises the deleted `.syllables` alias; profiling caption no longer claims "same machine" for reference numbers.

**Deferred with reasons** (noted, not done): unifying the web endpoint's separate column-mapper with the library loader (touches the deployed upload flow — follow-up with its own test); `pool_unb` set/array consolidation (hottest function, riskier than its payoff); the ragged zone-split batch optimization (load-time only). One release note surfaced: MaxEnt accuracy metrics shift vs 3.9.1 because elision lines now train — a modeling change, not a grammar change.

**679 pass** (677 + 2 new regression/property tests); `best_parse`+score+`num_parses` byte-identical across the sonnets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
