### PR TITLE
Fix vowel classification: glides are onsets, not nuclei (rhymes demot…

### DIFF
--- a/prosodic/texts/syll_df.py
+++ b/prosodic/texts/syll_df.py
@@ -7,7 +7,7 @@ One row per syllable, with all features needed by the vectorized parser.
 import numpy as np
 from ..imports import *
 from ..words.syllables import _parse_ipa_cached
-from ..words.phonemes import get_phoneme_feats
+from ..words.phonemes import get_phoneme_feats, phoneme_is_vowel
 
 # Experiment flag (default off = phonological weight for all syllables). When
 # True, function-word syllables are forced is_heavy=False, matching Prosodic v1's
@@ -19,12 +19,12 @@ FUNCTIONWORD_LIGHT = False
 
 
 def _phone_is_vowel(phone_txt):
-    """Check if a phone is a vowel using cached panphon features."""
-    feats = get_phoneme_feats(phone_txt)
-    cons = feats.get('cons')
-    if cons is None:
-        return None
-    return cons < 1
+    """Check if a phone is a vowel using cached panphon features.
+
+    Defers to Phoneme.is_vowel's rule rather than restating it, so the two parse
+    paths cannot drift on what counts as a nucleus.
+    """
+    return phoneme_is_vowel(get_phoneme_feats(phone_txt))
 
 
 def _phone_is_long(phone_txt):

--- a/prosodic/words/phonemes.py
+++ b/prosodic/words/phonemes.py
@@ -16,6 +16,33 @@ RHYME_FEATS = {
     'voi'
 }
 
+def phoneme_is_vowel(feats: Dict[str, Any]) -> Optional[bool]:
+    """
+    Determine from a phoneme's features whether it is a vowel.
+
+    The test is syllabicity, not consonantality. The glides /w/ and /j/ are
+    [-cons] exactly as every vowel is, and only [-syl] tells them apart, so
+    asking `cons` counted them as vowels: the onset of "warm" or "yes" was read
+    as part of the nucleus, and so carried into the rime.
+
+    Two feature schemas reach this function. Panphon's vectors spell the feature
+    `syl`; the ipa_info fallback, used for the symbols panphon has no vector for
+    (the affricates /ʧ/ and /ʤ/), spells it `syll`. Both are truthy-positive for
+    a nucleus, so one comparison serves.
+
+    Args:
+        feats (Dict[str, Any]): The phoneme's features.
+
+    Returns:
+        Optional[bool]: True if vowel, False if consonant, None if undetermined.
+    """
+    for key in ("syl", "syll"):
+        value = feats.get(key)
+        if value is not None:
+            return value > 0
+    return None
+
+
 class Phoneme(Entity):
     """
     Represents a phoneme with various attributes.
@@ -50,15 +77,8 @@ class Phoneme(Entity):
         Returns:
             Optional[bool]: True if vowel, False if consonant, None if undetermined.
         """
-        cons = self.feats.get('cons')
-        if cons is None:
-            return None
-        if cons > 0:
-            return False
-        if cons < 1:
-            return True
-        return None
-    
+        return phoneme_is_vowel(self.feats)
+
     @property
     def is_cons(self):
         return not self.is_vowel

--- a/prosodic/words/wordform.py
+++ b/prosodic/words/wordform.py
@@ -182,6 +182,17 @@ class WordForm(Entity):
             return np.nan
         return dist
 
+    def _has_coda(self) -> bool:
+        """Whether the rime closes on a consonant.
+
+        The slant band is coda identity with the nucleus left free, which is the
+        consonance of love/prove and gone/alone. Two open syllables share no coda
+        to be identical about, so without this they collect that licence for free
+        and any vowel-final word half-rhymes any other: away/tree, so/me.
+        """
+        rime = self.rime
+        return bool(rime) and not all(p.is_vowel for p in rime)
+
     @cache
     def rime_distance_nc(self, wordform: "WordForm"):
         """Decompose rime distance into (nucleus, coda) components.
@@ -262,7 +273,7 @@ class WordForm(Entity):
             return None
         if dn <= perfect_nuc_max and dc <= perfect_coda_max:
             return "perfect"
-        if dc <= slant_coda_max:
+        if dc <= slant_coda_max and self._has_coda() and wordform._has_coda():
             return "slant"
         if dn <= assonance_nuc_max:
             return "assonance"

--- a/tests/test_rhyme.py
+++ b/tests/test_rhyme.py
@@ -127,6 +127,45 @@ def test_rime_distance_nc():
     assert (dn, dc) == (0.0, 0.0)
 
 
+def test_glides_are_onsets_not_nuclei():
+    """A glide is [-cons] exactly as every vowel is, so classifying phonemes by
+    `cons` made /w/ and /j/ vowels: "warm" put its own onset in the nucleus and
+    carried it into the rime. Syllabicity is what separates the two."""
+    warm = _wf("warm")
+    syll = warm.syllables[0]
+    phons = list(syll.rime)  # accessing .rime is what annotates onset/rime
+    assert [p.txt for p in syll.children] == ["w", "ɔː", "r", "m"]
+    assert syll.children[0].is_vowel is False, "/w/ is a glide, not a vowel"
+    assert syll.children[0].is_onset, "/w/ opens the syllable"
+    assert [p.txt for p in phons] == ["ɔː", "r", "m"], "rime excludes the onset"
+    assert phons[0].is_nucleus and phons[-1].is_coda
+
+
+def test_glide_onset_does_not_demote_a_perfect_rhyme():
+    """What the misclassification cost: with half the nucleus apparently missing,
+    every perfect rhyme with a glide on one side came back 'slant'."""
+    for first, second in [
+        ("warm", "storm"),
+        ("way", "day"),
+        ("win", "sin"),
+        ("young", "sung"),
+        ("wing", "sing"),
+        ("yearn", "burn"),
+    ]:
+        pair = f"{first}/{second}"
+        assert _wf(first).rime_type(_wf(second)) == "perfect", pair
+        assert _wf(first).rime_distance_nc(_wf(second)) == (0.0, 0.0), pair
+
+
+def test_glides_do_not_make_a_diphthong():
+    """Syllable weight reads the same classification, so a glide counted as a
+    vowel also invented diphthongs: /wʌn/ and /mjə/ have one vowel each, and an
+    open short /mjə/ is light."""
+    assert _wf("one").syllables[0].has_dipthong is False
+    assert _wf("way").syllables[0].has_dipthong is True, "/eɪ/ is a real diphthong"
+    assert [s.weight for s in _wf("accumulate").syllables] == ["L", "H", "L", "H"]
+
+
 def test_line_rime_type():
     t = TextModel(
         "Shall I compare thee to a summer's day?\n"

--- a/tests/test_rhyme.py
+++ b/tests/test_rhyme.py
@@ -127,6 +127,32 @@ def test_rime_distance_nc():
     assert (dn, dc) == (0.0, 0.0)
 
 
+def test_two_open_syllables_are_not_a_slant_rhyme():
+    """The slant band is coda identity with the nucleus left free — the consonance
+    of love/prove, where a shared consonant is what licenses ignoring the vowel.
+    Two vowel-final words share no coda to be identical about, so granting them
+    that licence made every open syllable a half-rhyme of every other, however far
+    apart the vowels: away/tree sits at a nucleus distance of 0.72."""
+    for first, second in [
+        ("away", "tree"),
+        ("day", "see"),
+        ("so", "me"),
+        ("through", "play"),
+        ("blue", "free"),
+    ]:
+        pair = f"{first}/{second}"
+        assert _wf(first).rime_distance_nc(_wf(second))[1] == 0.0, pair
+        assert _wf(first).rime_type(_wf(second)) is None, pair
+
+    # What the band is for is untouched, because those pairs have a coda to share.
+    assert _wf("love").rime_type(_wf("prove")) == "slant"
+    assert _wf("gone").rime_type(_wf("alone")) == "slant"
+    # And open syllables that do rhyme were never the slant band's business: they
+    # match on the nucleus, which is the perfect band.
+    assert _wf("day").rime_type(_wf("may")) == "perfect"
+    assert _wf("tree").rime_type(_wf("free")) == "perfect"
+
+
 def test_glides_are_onsets_not_nuclei():
     """A glide is [-cons] exactly as every vowel is, so classifying phonemes by
     `cons` made /w/ and /j/ vowels: "warm" put its own onset in the nucleus and


### PR DESCRIPTION
This PR attempts to fix two issues with rhyme detection:
- glides were classified as vowels in some areas and consonants in others. This caused certain rhymes to be demoted or not detected: day is classified as a slant rhyme against away, and warm is not classified as a rhyme at all against scorn. 
- Slant rhyme detection allowed empty coda consonants to be seen as equal, which meant that every word that ended in a vowel sound got classified as a slant rhyme, no matter the vowel sound. Away rhymed with tree, and so with me.

Note: I don't have much experience with linguistics, and it may be that the approachs outlined here is incorrect or undesirable for some reason, in which case feel free to close the PR.

